### PR TITLE
refactor the writer interface and ionlog settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import "github.com/IonicHealthUsa/ionlog"
 
 func main() {
     ionlog.SetLogAttributes(
-        ionlog.WithTargets(ionlog.DefaultOutput()), // Log to console
+        ionlog.WithTargets(ionlog.DefaultOutput), // Log to console
         ionlog.WithStaticFields(map[string]string{"service": "my-app"}),
         ionlog.WithLogFileRotation("logs", 10*ionlog.Mebibyte, ionlog.Daily),
     )
@@ -37,15 +37,20 @@ import (
 )
 
 func main() {
-	// Set the log attributes, and other configurations
-	ionlog.SetLogAttributes(
-		// WithTargets sets the write targets for the logger, every log will be written
+	// SetAttributes set the log attributes, and other configurations
+	ionlog.SetAttributes(
+		// WithWriters sets the write targets for the logger, every log will be written
 		// to these targets.
-		ionlog.WithTargets(
-			ionlog.DefaultOutput(),
+		ionlog.WithWriters(
+			ionlog.CustomOutput,
 			// a websocket
 			// a file
 			// your custom writer
+		),
+
+		// (Optinal) WithoutTarget remove the writer targets for the logger. Pass the pointer of the writer.
+		ionlog.WithoutWriters(
+			// previously writer defined
 		),
 
 		// (Optional) WithStaticFields sets the static fields for the logger, every log will have these fields.
@@ -54,10 +59,21 @@ func main() {
 			// your custom fields
 		}),
 
+		// (Optional) WithoutStaticFields remove the static fields for the logger. Use the key of the static field to remove.
+		ionlog.WithoutStaticFields(
+			// previously static field defined
+		),
+
 		// (Optional) WithLogFileRotation enables log file rotation, specifying the directory where log files will be stored, the maximum size of the log folder in bytes, and the rotation frequency.
 		// This internal log rotation system appends the log file to the specified targets and automatically rotates logs based on the provided configuration,
 		// ensuring the total size of the log folder does not exceed the specified maximum (e.g., 10MB in this case).
 		ionlog.WithLogFileRotation("logs", 10*ionlog.Mebibyte, ionlog.Daily),
+
+		// (Optional) WithQueueSize sets the size of the reports queue, which stores logs before sending them to a file descriptor. For default, the size of report is 100.
+		ionlog.WithQueueSize(120),
+
+		// (Optional) WithTraceMode enables trace log mode. For default, the trace mode is disable, to enable is need pass a tru boolean.
+		ionlog.WithTraceMode(true),
 	)
 
 	// Start the logger service
@@ -71,20 +87,22 @@ func main() {
 	ionlog.Errorf("This log level is: %v", "error")
 	ionlog.Warnf("This log level is: %v", "warn")
 	ionlog.Debugf("This log level is: %v", "debug")
+	ionlog.Tracef("This log level is: %v", "trace")
 
 	ionlog.Info("This log level is a simple info log")
 	ionlog.Error("This log level is a simple error log")
 	ionlog.Warn("This log level is a simple warn log")
 	ionlog.Debug("This log level is a simple debug log")
+	ionlog.Trace("This log level is a simple trace log")
 
 	status := "NOT OK"
-	for i := 0; i < 10; i++ {
-		ionlog.LogOnceInfo("Process Started!")   // This will be logged only once
-		ionlog.LogOnChangeDebugf("count: %v", i) // Log every time i changes
+	for i := range 10 {
+		ionlog.LogOnceInfo("Process Started!") // This will be logged only once
+		ionlog.LogOnceDebugf("count: %v", i)   // Log every time i changes
 		if i == 5 {
 			status = "OK"
 		}
-		ionlog.LogOnChangeInfof("status: %v", status) // Log once "NOT OK", log once "OK"
+		ionlog.LogOnceInfof("status: %v", status) // Log once "NOT OK", log once "OK"
 	}
 }
 ```
@@ -94,7 +112,12 @@ func main() {
 
 ### Targets: Log to multiple destinations (console, files, websockets, custom writers).
 ```go
-ionlog.WithTargets(ionlog.DefaultOutput(), myCustomWriter)
+ionlog.WithTargets(ionlog.DefaultOutput, myCustomWriter)
+```
+
+### Targets: Remove the target.
+```go
+ionlog.WithoutTargets(ionlog.DefaultOutput, myCustomWriter)
 ```
 
 ### Static Fields: Add fixed fields to all logs (e.g., service name, environment).
@@ -102,9 +125,24 @@ ionlog.WithTargets(ionlog.DefaultOutput(), myCustomWriter)
 ionlog.WithStaticFields(map[string]string{"env": "production"})
 ```
 
+### Static Fields: Remove the static fields.
+```go
+ionlog.WithStaticFields("env")
+```
+
 ### Log Rotation: Auto-rotate logs by size and time.
 ```go
 ionlog.WithLogFileRotation("logs", 100*ionlog.Mebibyte, ionlog.Hourly)
+```
+
+### Report Size: sets the size pf reports queue.
+```go
+ionlog.WithQueueSize(200)
+```
+
+### Trace: enable or disable the trace mode.
+```go
+ionlog.WithTraceMode(true)
 ```
 
 ## Logging Functions
@@ -112,6 +150,11 @@ ionlog.WithLogFileRotation("logs", 100*ionlog.Mebibyte, ionlog.Hourly)
 ```go
 ionlog.Infof("User %s logged in", "Alice")
 ionlog.Error("Connection failed")
+```
+
+- The trace level is optional. It is necessary to enable.
+```go
+ionlog.Trace("Trace the path")
 ```
 
 ## Structured Output: Logs are emitted as JSON with metadata:
@@ -138,19 +181,115 @@ ionlog.LogOnceInfo("Initialization complete")
 ### Log on Change: Only log when the value changes.
 ```go
 status := "STARTING"
-ionlog.LogOnChangeInfof("status: %s", status) // Logs once
-ionlog.LogOnChangeInfof("status: %s", status) // Will not log
+ionlog.LogOnceInfof("status: %s", status) // Logs once
+ionlog.LogOnceInfof("status: %s", status) // Will not log
 
 status = "RUNNING"
-ionlog.LogOnChangeInfof("status: %s", status) // Logs again
-ionlog.LogOnChangeInfof("status: %s", status) // Will not log
+ionlog.LogOnceInfof("status: %s", status) // Logs again
+ionlog.LogOnceInfof("status: %s", status) // Will not log
 ```
 
 ## Lifecycle Management:
 
 - Start() initializes the logger
+```go
+ionlog.Start()
+```
+
 - Stop() closes the logger when the program ends
+```go
+ionlog.Stop()
+```
 
 
 # Internal Logging system:
 - Internal logs are handled by the slog package, and outputed to the os.Stdout by default.
+
+
+# Process Flow Diagram
+```mermaid
+sequenceDiagram
+    participant P as User/Third-Party Program
+    participant I as Ionlog Core
+    participant S as Ionlog Settings
+    participant H as Processing Handlers
+    participant W as Writer Interface
+    participant O as Output
+
+    P->>I: 1. Initialize Ionlog (e.g., ionlog.SetDefault())
+    activate I
+    I->>S: 2. Load initial settings (Level, Format, Handlers, Writers, etc.)
+    activate S
+    S-->>I: 3. Return loaded settings
+    deactivate S
+    I-->>P: 4. Ionlog ready for use
+    deactivate I
+
+
+    P->>I: 5. Start logger service
+	I->>H: 6. Inicitialize the handler
+
+
+    P->>I: 7. Call log function (e.g., log.Info(), log.Error("msg"))
+    activate I
+    I->>S: 8. Query settings (trace mode, static fields, active writers)
+    activate S
+    S-->>I: 9. Return relevant settings for the event
+    deactivate S
+
+    alt Log level of event was configured 
+        I->>H: 10. Forward log event to configured Handlers
+        activate H
+        H-->>H: 11. Format log message and metadata (e.g., JSON, plain text)
+        Note over H: Other processing handlers (e.g., enrichment) may also apply here.
+
+        opt Log Once Handler
+            H-->>H: 12. Filter log event (if applicable, based on tags, fields, etc.)
+            alt Event Filtered and Discarded
+                H--xI: 13. Event discarded by filter
+                Note over P,H: The log is ignored because it was already logged before.
+                I-->>P: 14. Return (log event ignored)
+            end
+        end
+
+        H-->>I: 15. Return processed log event
+        deactivate H
+
+        I->>W: 16. Send processed log event to configured Writers
+        activate W
+        opt Custom Output Processing
+            W-->>W: 17. Customize log for the specific output
+        end
+        W->>O: 18. Write/Display log to concrete Output (Console, File, File Descriptor, etc.)
+        activate O
+        O-->>W: 19. Confirmation of write (or error)
+        deactivate O
+        W-->>I: 20. Confirmation of write to Core
+        deactivate W
+        I-->>P: 21. End of log operation
+    else Log level of event was not configured 
+        I-->>P: 10. Log event ignored (level below configured)
+        deactivate I
+    end
+
+
+    opt Stop logger service
+    P->>I: 22. Stop Ionlog
+    activate I
+    I->>H: 23. Signal Handlers to shut down (e.g., flush buffers, close resources)
+    activate H
+    H-->>I: 24. Handlers shut down confirmation
+    deactivate H
+    I->>W: 25. Signal Writers to shut down (e.g., flush pending writes, close file handles)
+    activate W
+    W->>O: 26. Perform final flush/cleanup on Outputs
+    activate O
+    O-->>W: 27. Outputs cleanup complete
+    deactivate O
+    W-->>I: 28. Writers shut down confirmation
+    deactivate W
+    I-->>P: 29. Ionlog shutdown complete
+    deactivate I
+
+    end
+```

--- a/benchmark/basiclogs_test.go
+++ b/benchmark/basiclogs_test.go
@@ -9,8 +9,8 @@ import (
 var fakeMessage = "We shall not cease from exploration and the end of all our exploring will be to arrive where we started and know the place for the first time."
 
 func BenchmarkBasicLogs(b *testing.B) {
-	ionlog.SetAttributes(ionlog.SetQueueSize(1000))
-	ionlog.SetTraceMode(true)
+	ionlog.SetAttributes(ionlog.WithQueueSize(1000))
+	ionlog.WithTraceMode(true)
 
 	ionlog.Start()
 	defer ionlog.Stop()
@@ -77,8 +77,8 @@ func BenchmarkBasicLogs(b *testing.B) {
 }
 
 func BenchmarkBasicLogsParallel(b *testing.B) {
-	ionlog.SetAttributes(ionlog.SetQueueSize(1000))
-	ionlog.SetTraceMode(true)
+	ionlog.SetAttributes(ionlog.WithQueueSize(1000))
+	ionlog.WithTraceMode(true)
 
 	ionlog.Start()
 	defer ionlog.Stop()

--- a/benchmark/logonce_test.go
+++ b/benchmark/logonce_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func BenchmarkLogOnceNoChange(b *testing.B) {
-	ionlog.SetAttributes(ionlog.SetQueueSize(1000))
+	ionlog.SetAttributes(ionlog.WithQueueSize(1000))
 	ionlog.Start()
 	defer ionlog.Stop()
 
@@ -64,7 +64,7 @@ func BenchmarkLogOnceNoChange(b *testing.B) {
 }
 
 func BenchmarkLogOnceWithChange(b *testing.B) {
-	ionlog.SetAttributes(ionlog.SetQueueSize(1000))
+	ionlog.SetAttributes(ionlog.WithQueueSize(1000))
 	ionlog.Start()
 	defer ionlog.Stop()
 
@@ -118,7 +118,7 @@ func BenchmarkLogOnceWithChange(b *testing.B) {
 }
 
 func BenchmarkLogOnceNoChangeParallel(b *testing.B) {
-	ionlog.SetAttributes(ionlog.SetQueueSize(1000))
+	ionlog.SetAttributes(ionlog.WithQueueSize(1000))
 	ionlog.Start()
 	defer ionlog.Stop()
 
@@ -188,7 +188,7 @@ func BenchmarkLogOnceNoChangeParallel(b *testing.B) {
 }
 
 func BenchmarkLogOnceWithChangeParallel(b *testing.B) {
-	ionlog.SetAttributes(ionlog.SetQueueSize(1000))
+	ionlog.SetAttributes(ionlog.WithQueueSize(1000))
 	ionlog.Start()
 	defer ionlog.Stop()
 

--- a/internal/core/logengine/logger_test.go
+++ b/internal/core/logengine/logger_test.go
@@ -1,8 +1,700 @@
 package logengine
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/IonicHealthUsa/ionlog/internal/core/runtimeinfo"
 )
 
 func TestNewLogger(t *testing.T) {
+	t.Run("should return logger instance", func(t *testing.T) {
+		l := NewLogger()
+		if l == nil {
+			t.Error("NewLogger did not returned a interface of logger")
+		}
+		if reflect.ValueOf(l).IsNil() {
+			t.Error("expected a value to logger")
+		}
+
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatal("NewLogger did not returned a instance of logger")
+		}
+
+		if _l.builder == nil {
+			t.Error("expected the momory was instance")
+		}
+		if reflect.ValueOf(_l.builder).IsNil() {
+			t.Error("expected the builder was not nil")
+		}
+
+		if _l.logsMemory == nil {
+			t.Error("expected the momory was instance")
+		}
+		if reflect.ValueOf(_l.logsMemory).IsNil() {
+			t.Error("expected the momory was not nil")
+		}
+
+		if _l.reports == nil {
+			t.Error("expected a chan to reports")
+		}
+
+		if _l.writer == nil {
+			t.Error("expected the writes was instace")
+		}
+		if reflect.ValueOf(_l.writer).IsNil() {
+			t.Error("expected the write was not nil")
+		}
+	})
+}
+
+func TestCloseReport(t *testing.T) {
+	t.Run("should close the asynchronous report", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		_l.closeLock.Lock()
+		if _l.closed {
+			t.Errorf("expected the closed report to be %v, but got %v", false, _l.closed)
+		}
+		_l.closeLock.Unlock()
+
+		_l.closeReport()
+
+		_l.closeLock.Lock()
+		if !_l.closed {
+			t.Errorf("expected the closed report to be %v, but got %v", true, _l.closed)
+		}
+		_l.closeLock.Unlock()
+	})
+
+	t.Run("should timeout when the mutex is lock", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		_l.closeLock.Lock()
+		go _l.closeReport()
+
+		if _l.closed {
+			t.Errorf("expected the closed report to be false, but got %v", _l.closed)
+		}
+
+		_l.closeLock.Unlock()
+		<-time.After(time.Millisecond)
+
+		_l.closeLock.Lock()
+		if !_l.closed {
+			t.Errorf("expected the closed report to be true, but got %v", _l.closed)
+		}
+		_l.closeLock.Unlock()
+	})
+}
+
+func TestGetStatusCloseReport(t *testing.T) {
+	t.Run("should get the status of reports closed", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		if _l.getStatusCloseReport() {
+			t.Errorf("expected the closed report to be %v, but got %v", false, _l.getStatusCloseReport())
+		}
+
+		_l.closed = true
+
+		if !_l.getStatusCloseReport() {
+			t.Errorf("expected the closed report to be %v, but got %v", true, _l.getStatusCloseReport())
+		}
+	})
+
+	t.Run("should timeout when mutex is lock", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		_l.closeLock.Lock()
+		comm := make(chan bool, 1)
+		go func() {
+			comm <- _l.getStatusCloseReport()
+		}()
+
+		select {
+		case c := <-comm:
+			t.Errorf("expected no response, but got %v", c)
+		case <-time.After(time.Millisecond):
+		}
+
+		_l.closeLock.Unlock()
+		select {
+		case <-comm:
+		case <-time.After(time.Millisecond):
+			t.Error("expected a response, but got nothing")
+		}
+	})
+}
+
+func TestAsyncReport(t *testing.T) {
+	r := Report{
+		Time:       time.Now().Format(time.RFC3339),
+		Level:      Info,
+		Msg:        "Hello World",
+		CallerInfo: runtimeinfo.GetCallerInfo(1),
+	}
+
+	t.Run("should receive the report", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		l.AsyncReport(r)
+
+		select {
+		case report := <-_l.reports:
+			if report.Time != r.Time {
+				t.Errorf("expected time to be %q, but got %q", r.Time, report.Time)
+			}
+			if report.Level != r.Level {
+				t.Errorf("expected level to be %q, but got %q", r.Level, report.Level)
+			}
+			if report.Msg != r.Msg {
+				t.Errorf("expected message to be %q, but got %q", r.Msg, report.Msg)
+			}
+			if report.CallerInfo.File != r.CallerInfo.File {
+				t.Errorf("expected file info to be %q, but got %q", r.CallerInfo.File, report.CallerInfo.File)
+			}
+			if report.CallerInfo.Line != r.CallerInfo.Line {
+				t.Errorf("expected line info to be %q, but got %q", r.CallerInfo.Line, report.CallerInfo.Line)
+			}
+			if report.CallerInfo.Package != r.CallerInfo.Package {
+				t.Errorf("expected package info to be %q, but got %q", r.CallerInfo.Package, report.CallerInfo.Package)
+			}
+			if report.CallerInfo.Function != r.CallerInfo.Function {
+				t.Errorf("expected function info to be %q, but got %q", r.CallerInfo.Function, report.CallerInfo.Function)
+			}
+		case <-time.After(time.Second):
+			t.Error("expected a report, but timeout")
+		}
+	})
+
+	t.Run("should timeout when logger is closed", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		_l.closed = true
+		l.AsyncReport(r)
+
+		select {
+		case <-_l.reports:
+			t.Error("expected no report, but got")
+		case <-time.After(time.Second):
+		}
+	})
+
+	t.Run("should timeout when report channel is full", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+		_l.reports = make(chan Report)
+
+		l.AsyncReport(r)
+
+		select {
+		case <-_l.reports:
+			t.Error("expected no report, but got")
+		case <-time.After(time.Second):
+		}
+	})
+}
+
+type mockBufferWriter struct {
+	lock sync.Mutex
+	buf  bytes.Buffer
+}
+
+func (m *mockBufferWriter) Write(p []byte) (n int, err error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.buf.Write(p)
+}
+
+func (m *mockBufferWriter) String() string {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.buf.String()
+}
+
+func TestReport(t *testing.T) {
+	r := Report{
+		Time:       time.Now().Format(time.RFC3339),
+		Level:      Info,
+		Msg:        "Hello World",
+		CallerInfo: runtimeinfo.GetCallerInfo(1),
+	}
+
+	reportLog := fmt.Sprintf(`"time":"%s","level":"%s","msg":"%s","file":"%s","package":"%s","function":"%s","line":"%d"}
+`, r.Time, r.Level, r.Msg, r.CallerInfo.File, r.CallerInfo.Package, r.CallerInfo.Function, r.CallerInfo.Line)
+
+	t.Run("should timout when mutex is lock", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		buf := &mockBufferWriter{}
+		_l.writer.AddWriter(buf)
+
+		expectedReport := "{" + reportLog
+
+		_l.reportLock.Lock()
+
+		go l.Report(r)
+		time.Sleep(10 * time.Millisecond)
+
+		if buf.String() != "" {
+			t.Errorf("expected nothing on buffer, but got %q", buf.String())
+		}
+
+		_l.reportLock.Unlock()
+		time.Sleep(10 * time.Millisecond)
+
+		if buf.String() != expectedReport {
+			t.Errorf("expected read on buffer %q, but got %q", expectedReport, buf.String())
+		}
+	})
+
+	t.Run("should write the information of report", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		buf := &mockBufferWriter{}
+
+		_l.writer.AddWriter(buf)
+
+		l.Report(r)
+
+		expectedReport := "{" + reportLog
+
+		if buf.String() != expectedReport {
+			t.Errorf("expected read on buffer %q, but got %q", expectedReport, buf.String())
+		}
+	})
+
+	t.Run("should write the key and value when staticFields is not empty", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		attrs := make(map[string]string, 1)
+		attrs["hello"] = "world"
+		helloReport := `{"hello":"world",`
+		expectedReport := helloReport + reportLog
+
+		_l.staticFields = attrs
+
+		buf := &bytes.Buffer{}
+		_l.writer.AddWriter(buf)
+
+		l.Report(r)
+
+		if buf.String() != expectedReport {
+			t.Errorf("expected read on buffer %q, but got %q", expectedReport, buf.String())
+		}
+	})
+}
+
+func TestFlushReports(t *testing.T) {
+	r := Report{
+		Time:       time.Now().Format(time.RFC3339),
+		Level:      Info,
+		Msg:        "Hello World",
+		CallerInfo: runtimeinfo.GetCallerInfo(1),
+	}
+
+	reportLog := fmt.Sprintf(`{"time":"%s","level":"%s","msg":"%s","file":"%s","package":"%s","function":"%s","line":"%d"}
+`, r.Time, r.Level, r.Msg, r.CallerInfo.File, r.CallerInfo.Package, r.CallerInfo.Function, r.CallerInfo.Line)
+
+	t.Run("should not flush any report when buffer reports is empty", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		buf := &bytes.Buffer{}
+		_l.writer.AddWriter(buf)
+
+		l.FlushReports()
+
+		if buf.String() != "" {
+			t.Errorf("expected nothing on buffer, but got %q", buf.String())
+		}
+	})
+
+	t.Run("should flush the report", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		buf := &bytes.Buffer{}
+		_l.writer.AddWriter(buf)
+
+		_l.reports <- r
+
+		l.FlushReports()
+
+		if buf.String() != reportLog {
+			t.Errorf("expected read on buffer %q, but got %q", reportLog, buf.String())
+		}
+	})
+}
+
+func TestHandleReports(t *testing.T) {
+	r := Report{
+		Time:       time.Now().Format(time.RFC3339),
+		Level:      Info,
+		Msg:        "Hello World",
+		CallerInfo: runtimeinfo.GetCallerInfo(1),
+	}
+
+	reportLog := fmt.Sprintf(`{"time":"%s","level":"%s","msg":"%s","file":"%s","package":"%s","function":"%s","line":"%d"}
+`, r.Time, r.Level, r.Msg, r.CallerInfo.File, r.CallerInfo.Package, r.CallerInfo.Function, r.CallerInfo.Line)
+
+	t.Run("should handle the report and close the logger", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("NewLogger did not returned a instance of logger")
+		}
+
+		buf := &mockBufferWriter{}
+		_l.writer.AddWriter(buf)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go l.HandleReports(ctx)
+
+		_l.reports <- r
+		time.Sleep(time.Millisecond)
+
+		if buf.String() != reportLog {
+			t.Errorf("expected read on buffer %q, but got %q", reportLog, buf.String())
+		}
+
+		cancel()
+		time.Sleep(time.Millisecond)
+		if !_l.getStatusCloseReport() {
+			t.Error("expected report handle reports to be closed, but remain open")
+		}
+
+		buf.buf.Reset()
+		_l.reports <- r
+		time.Sleep(time.Millisecond)
+
+		if buf.String() != "" {
+			t.Errorf("expected nothing on buffer, but got %q", buf.String())
+		}
+	})
+}
+
+func TestWriter(t *testing.T) {
+	t.Run("should return the writers set on logger", func(t *testing.T) {
+		l := NewLogger()
+
+		w := l.Writer()
+		if w == nil {
+			t.Error("expected the writes was instace")
+		}
+		if reflect.ValueOf(w).IsNil() {
+			t.Error("expected the write was empty")
+		}
+	})
+}
+
+func TestMemory(t *testing.T) {
+	t.Run("should return the record memory", func(t *testing.T) {
+		l := NewLogger()
+
+		m := l.Memory()
+		if m == nil {
+			t.Error("expected the memory was instace")
+		}
+		if reflect.ValueOf(m).IsNil() {
+			t.Error("expected the memory was empty")
+		}
+	})
+}
+
+func TestSetStaticFields(t *testing.T) {
+	t.Run("should set the static fields", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		attrs := make(map[string]string, 2)
+		attrs["hello"] = "world"
+		attrs["ionic"] = "health"
+
+		l.SetStaticFields(attrs)
+
+		if len(_l.staticFields) != len(attrs) {
+			t.Errorf("expected the size of static field to be %q, but got %q", len(attrs), len(_l.staticFields))
+		}
+
+		for key, value := range attrs {
+			if _l.staticFields[key] != value {
+				t.Errorf("expected the value of static fields with key=%v to be %q, but got %q", key, value, _l.staticFields[key])
+			}
+		}
+
+		for key, value := range _l.staticFields {
+			if value != attrs[key] {
+				t.Errorf("expected the l.staticFields[%q]=%q was set on attrs, but got %q", key, value, attrs[key])
+			}
+		}
+	})
+
+	t.Run("should add the static fields when already exist", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		attrs := make(map[string]string, 2)
+		attrs["hello"] = "world"
+		attrs["ionic"] = "health"
+
+		l.SetStaticFields(attrs)
+
+		if len(_l.staticFields) != len(attrs) {
+			t.Errorf("expected the size of static field to be %q, but got %q", len(attrs), len(_l.staticFields))
+		}
+
+		for key, value := range attrs {
+			if _l.staticFields[key] != value {
+				t.Errorf("expected the value of static fields with key=%v to be %q, but got %q", key, value, _l.staticFields[key])
+			}
+		}
+
+		for key, value := range _l.staticFields {
+			if value != attrs[key] {
+				t.Errorf("expected the l.staticFields[%q]=%q was set on attrs, but got %q", key, value, attrs[key])
+			}
+		}
+
+		newAttrs := make(map[string]string, 1)
+		newAttrs["test"] = "123"
+
+		l.SetStaticFields(newAttrs)
+
+		if len(_l.staticFields) != 3 {
+			t.Errorf("expected the size of static field to be %q, but got %q", 3, len(_l.staticFields))
+		}
+
+		for key, value := range newAttrs {
+			if _l.staticFields[key] != value {
+				t.Errorf("expected the value of static fields with key=%v to be %q, but got %q", key, value, _l.staticFields[key])
+			}
+		}
+	})
+}
+
+func TestDeleteStaticField(t *testing.T) {
+	t.Run("should remove the static field", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		attrs := make(map[string]string, 2)
+		attrs["hello"] = "world"
+		attrs["ionic"] = "health"
+
+		expectedStaticField := make(map[string]string, 1)
+		expectedStaticField["ionic"] = "health"
+
+		_l.staticFields = attrs
+
+		l.DeleteStaticField("hello")
+
+		if len(_l.staticFields) != 1 {
+			t.Errorf("expected the size of static fields to be 1, but got %q", len(_l.staticFields))
+		}
+
+		for k, v := range _l.staticFields {
+			if v != expectedStaticField[k] {
+				t.Errorf("expected the value with the key=%q to be %q, but got %q", k, expectedStaticField[k], v)
+			}
+		}
+
+		for k, v := range expectedStaticField {
+			if v != _l.staticFields[k] {
+				t.Errorf("expected the static field to be equal of expected static field, but expected to be %q and got %q for key=%q", v, _l.staticFields[k], k)
+			}
+		}
+	})
+
+	t.Run("should remove all static field", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		attrs := make(map[string]string, 2)
+		attrs["hello"] = "world"
+		attrs["ionic"] = "health"
+
+		_l.staticFields = attrs
+
+		if len(_l.staticFields) != 2 {
+			t.Errorf("expected the size of static field to be %q, but got %q", 2, len(_l.staticFields))
+		}
+
+		for k := range attrs {
+			_l.DeleteStaticField(k)
+		}
+
+		if len(_l.staticFields) != 0 {
+			t.Errorf("expected the size of static field to be %q, but got %q", 0, len(_l.staticFields))
+		}
+	})
+
+	t.Run("should remove all static field with one call", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		attrs := make(map[string]string, 2)
+		attrs["hello"] = "world"
+		attrs["ionic"] = "health"
+
+		_l.staticFields = attrs
+
+		if len(_l.staticFields) != 2 {
+			t.Errorf("expected the size of static field to be %d, but got %d", 2, len(_l.staticFields))
+		}
+
+		_l.DeleteStaticField("hello", "ionic")
+
+		if len(_l.staticFields) != 0 {
+			t.Errorf("expected the size of static field to be %d, but got %d", 0, len(_l.staticFields))
+		}
+	})
+}
+
+func TestSetReportQueueSize(t *testing.T) {
+	t.Run("should set the size of record reports", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		size := 100
+		l.SetReportQueueSize(uint(size))
+
+		if cap(_l.reports) != size {
+			t.Errorf("expected the size of report to be %v, but got %q", size, cap(_l.reports))
+		}
+	})
+}
+
+func TestSetTraceMode(t *testing.T) {
+	t.Run("should set trace mode to true", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		mode := true
+		l.SetTraceMode(mode)
+
+		if _l.traceMode != mode {
+			t.Errorf("expected the trace mode to be %v, but got %v", mode, _l.traceMode)
+		}
+	})
+
+	t.Run("should set the trace mode to false", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		mode := false
+		l.SetTraceMode(mode)
+
+		if _l.traceMode != mode {
+			t.Errorf("expected the trace mode to be %v, but got %v", mode, _l.traceMode)
+		}
+	})
+}
+
+func TestTraceMode(t *testing.T) {
+	t.Run("should return the trace mode (true)", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		mode := true
+		_l.traceMode = mode
+
+		if l.TraceMode() != mode {
+			t.Errorf("expected the trace mode to be %v, but got %v", mode, l.TraceMode())
+		}
+	})
+
+	t.Run("should return the trace mode (false)", func(t *testing.T) {
+		l := NewLogger()
+		_l, ok := l.(*logger)
+		if !ok {
+			t.Fatalf("newlogger did not returned a instance of logger")
+		}
+
+		mode := false
+		_l.traceMode = mode
+
+		if l.TraceMode() != mode {
+			t.Errorf("expected the trace mode to be %v, but got %v", mode, l.TraceMode())
+		}
+	})
 }

--- a/internal/core/rotationengine/rotation_test.go
+++ b/internal/core/rotationengine/rotation_test.go
@@ -1,0 +1,710 @@
+package rotationengine
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNewRotationEngine(t *testing.T) {
+	folderName := "rotation_engine"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should return rotation engine interface", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		if r == nil {
+			t.Error("expected a interface of rotation engine")
+		}
+		if reflect.ValueOf(r).IsNil() {
+			t.Error("expected a value of rotation engine")
+		}
+
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		if _r.folder != folderName {
+			t.Errorf("expected folder name to be %q, but got %q", folderName, _r.folder)
+		}
+		if _r.maxFolderSize != maxFolderSize {
+			t.Errorf("expected max folder size to be %q, but got %q", maxFolderSize, _r.maxFolderSize)
+		}
+		if _r.rotation != rotation {
+			t.Errorf("expected rotation to be %q, but got %q", rotation, _r.rotation)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestWrite(t *testing.T) {
+	folderName := "rotation_write"
+	maxFolderSize := GB
+	rotation := Daily
+
+	msg := []byte("Hello World")
+
+	t.Run("should failure when write on nil logfile", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		_r.logFile = nil
+
+		n, err := r.Write(msg)
+		if n != 0 {
+			t.Errorf("expected length of message to be %q, but got %q", 0, n)
+		}
+		if err != ErrLogFileNotSet {
+			t.Errorf("expected error to be %q, but got %q", ErrLogFileNotSet, err)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should write on logfile", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		_r.createNewFile()
+		if _r.logFile == nil {
+			t.Errorf("new logfile not created")
+		}
+
+		n, err := r.Write(msg)
+		if n != len(msg) {
+			t.Errorf("expected the length of message to be %q, but got %d", len(msg), n)
+		}
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		fileName, err := _r.getMostRecentLogFile()
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		content, err := os.ReadFile(filepath.Join(_r.folder, fileName))
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+		if !reflect.DeepEqual(content, msg) {
+			t.Errorf("expected the message writen on file was %q, but got %q", string(msg), string(content))
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestAutoChecks(t *testing.T) {
+
+}
+
+func TestCloseLogFile(t *testing.T) {
+	folderName := "rotaion_close"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should close the logfile", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		_r.createNewFile()
+		if _r.logFile == nil {
+			t.Errorf("new logfile not created")
+		}
+
+		r.CloseLogFile()
+		if _r.logFile != nil {
+			t.Errorf("expected the logfile to be closed")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestCloseFile(t *testing.T) {
+	folderName := "rotaion_close"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should close the logfile", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		_r.createNewFile()
+		if _r.logFile == nil {
+			t.Errorf("new logfile not created")
+		}
+
+		_r.closeFile()
+		if _r.logFile != nil {
+			t.Errorf("expected the logfile to be closed")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+type mockWriteCloser struct {
+	*bufio.Writer
+}
+
+func (m *mockWriteCloser) Write(p []byte) (int, error) {
+	return 0, nil
+}
+
+func (m *mockWriteCloser) Close() error {
+	return nil
+}
+
+func TestSetLogFile(t *testing.T) {
+	folderName := "rotaion_setlogfile"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should not set the logfile when file is nil", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		_r.logFile = nil
+
+		_r.setLogFile(nil)
+		if _r.logFile != nil {
+			t.Error("expected the logfile to be not set")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should set the logfile", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		_r.logFile = nil
+
+		file := &mockWriteCloser{}
+
+		_r.setLogFile(file)
+		if _r.logFile != file {
+			t.Error("expected the logfile to be set")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestAutoRotate(t *testing.T) {
+	folderName := "rotaion_autorotate"
+	maxFolderSize := GB
+	rotation := Daily
+	rotations := []PeriodicRotation{Daily, Weekly, Monthly}
+
+	t.Run("should create a new logfile when none exists", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		fileName, err := _r.getMostRecentLogFile()
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		err = os.RemoveAll(filepath.Join(_r.folder, fileName))
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		_r.logFile = nil
+
+		_r.autoRotate()
+
+		if _r.logFile == nil {
+			t.Error("expected the logfile set")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should create a new logfile when the file need rotate", func(t *testing.T) {
+		for _, rot := range rotations {
+			r := NewRotationEngine(folderName, maxFolderSize, rot)
+			_r, ok := r.(*rotationEngine)
+			if !ok {
+				t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+			}
+
+			fileName, err := _r.getMostRecentLogFile()
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+
+			err = os.RemoveAll(filepath.Join(_r.folder, fileName))
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+
+			filename := fmt.Sprintf(logFilePattern, "2000-01-01")
+			filePath := filepath.Join(_r.folder, filename)
+
+			_, err = _r.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err.Error())
+				return
+			}
+
+			_r.logFile = nil
+
+			_r.autoRotate()
+
+			if _r.logFile == nil {
+				t.Error("expected the logfile set")
+			}
+
+			fileName, err = _r.getMostRecentLogFile()
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+
+			fileDate, err := _r.getFileDate(fileName)
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+
+			if fileDate.Format(time.DateOnly) != time.Now().Format(time.DateOnly) {
+				t.Errorf("expected the most recently file to be %q, but got %q", time.Now().Format(time.DateOnly), fileDate.Format(time.DateOnly))
+			}
+
+			if _, err := os.Stat(folderName); err != nil {
+				t.Errorf("expected a diretory %q, but did not exist", folderName)
+			}
+			if err := os.RemoveAll(folderName); err != nil {
+				t.Error("expected remove all file and the directory")
+			}
+		}
+	})
+
+	t.Run("should not rotate the file when set NoAutoRotate", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, NoAutoRotate)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		fileName, err := _r.getMostRecentLogFile()
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		err = os.RemoveAll(filepath.Join(_r.folder, fileName))
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		filename := fmt.Sprintf(logFilePattern, "2000-01-01")
+		filePath := filepath.Join(_r.folder, filename)
+
+		_, err = _r.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			return
+		}
+
+		_r.logFile = nil
+
+		_r.autoRotate()
+
+		if _r.logFile == nil {
+			t.Error("expected the logfile set")
+		}
+
+		fileName, err = _r.getMostRecentLogFile()
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		fileDate, err := _r.getFileDate(fileName)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		if fileDate.Format(time.DateOnly) != "2000-01-01" {
+			t.Errorf("expected the most recently file to be %q, but got %q", "2000-01-01", fileDate.Format(time.DateOnly))
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should set the logfile with the most recent log file when logfile is nil", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		_r.logFile = nil
+
+		_r.autoRotate()
+
+		if _r.logFile == nil {
+			t.Error("expected the logfile set")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should not set the logfile when the file is not a valid log file", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, NoAutoRotate)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		fileName, err := _r.getMostRecentLogFile()
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		err = os.RemoveAll(filepath.Join(_r.folder, fileName))
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		filename := fmt.Sprintf(logFilePattern, "new-file")
+		filePath := filepath.Join(_r.folder, filename)
+
+		_, err = _r.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			return
+		}
+
+		_r.logFile = nil
+
+		_r.autoRotate()
+
+		if _r.logFile == nil {
+			t.Error("expected the logfile set")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestAutoCheckFolderSize(t *testing.T) {
+	folderName := "rotaion_autorotate"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should not create a new log file when do not have max folder size", func(t *testing.T) {
+		r := NewRotationEngine(folderName, NoMaxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		files, err := os.ReadDir(_r.folder)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		for _, file := range files {
+			err = os.Remove(filepath.Join(_r.folder, file.Name()))
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		}
+
+		_r.logFile = nil
+
+		_r.autoCheckFolderSize()
+
+		if _r.logFile != nil {
+			t.Error("expected the logfile not set")
+		}
+
+		_, err = _r.getMostRecentLogFile()
+		if err != ErrNoLogFileFound {
+			t.Errorf("expected error to be %q, but got %q", ErrNoLogFileFound, err)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should not create a new log file when the folder not set", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		files, err := os.ReadDir(_r.folder)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		for _, file := range files {
+			err = os.Remove(filepath.Join(_r.folder, file.Name()))
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		}
+
+		_r.logFile = nil
+		_r.folder = ""
+
+		_r.autoCheckFolderSize()
+
+		_r.folder = folderName
+
+		if _r.logFile != nil {
+			t.Error("expected the logfile not set")
+		}
+
+		_, err = _r.getMostRecentLogFile()
+		if err != ErrNoLogFileFound {
+			t.Errorf("expected error to be %q, but got %q", ErrNoLogFileFound, err)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should not create a new log file when the max folder size do not reached", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		files, err := os.ReadDir(_r.folder)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		for _, file := range files {
+			err = os.Remove(filepath.Join(_r.folder, file.Name()))
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		}
+
+		_r.logFile = nil
+
+		_r.autoCheckFolderSize()
+
+		if _r.logFile != nil {
+			t.Error("expected the logfile not set")
+		}
+
+		_, err = _r.getMostRecentLogFile()
+		if err != ErrNoLogFileFound {
+			t.Errorf("expected error to be %q, but got %q", ErrNoLogFileFound, err)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should not create a new log file when the folder do not have any log files", func(t *testing.T) {
+		r := NewRotationEngine(folderName, uint(1), rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		files, err := os.ReadDir(_r.folder)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		for _, file := range files {
+			err = os.Remove(filepath.Join(_r.folder, file.Name()))
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		}
+
+		// Create a generic file to popularize the folder
+		file, err := os.Create(filepath.Join(_r.folder, "HelloWorld.txt"))
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+		if _, err := file.Write([]byte("Hello World!!!")); err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		_r.logFile = nil
+
+		_r.autoCheckFolderSize()
+
+		if _r.logFile != nil {
+			t.Error("expected the logfile not set")
+		}
+
+		_, err = _r.getMostRecentLogFile()
+		if err != ErrNoLogFileFound {
+			t.Errorf("expected error to be %q, but got %q", ErrNoLogFileFound, err)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should remove the old file and create a new file", func(t *testing.T) {
+		r := NewRotationEngine(folderName, uint(1), rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instace of rotation engine")
+		}
+
+		files, err := os.ReadDir(_r.folder)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		for _, file := range files {
+			err = os.Remove(filepath.Join(_r.folder, file.Name()))
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		}
+
+		fileName := fmt.Sprintf(logFilePattern, "2000-01-01")
+		filePath := filepath.Join(_r.folder, fileName)
+
+		oldFileLog, err := _r.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+		if _, err := oldFileLog.Write([]byte("Hello World!!!")); err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		_r.logFile = nil
+
+		_r.autoCheckFolderSize()
+
+		if _r.logFile == nil {
+			t.Error("expected the logfile set")
+		}
+
+		fileName, err = _r.getMostRecentLogFile()
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		fileDate, err := _r.getFileDate(fileName)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		if fileDate.Format(time.DateOnly) != time.Now().Format(time.DateOnly) {
+			t.Errorf("expected the most recently file to be %q, but got %q", time.Now().Format(time.DateOnly), fileDate.Format(time.DateOnly))
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a diretory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}

--- a/internal/core/rotationengine/utils.go
+++ b/internal/core/rotationengine/utils.go
@@ -79,6 +79,12 @@ func (r *rotationEngine) getMostRecentLogFile() (string, error) {
 
 // createNewFile creates a new log file in the specified folder.
 func (r *rotationEngine) createNewFile() {
+	_, err := r.ReadDir(r.folder)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		return
+	}
+
 	filename := fmt.Sprintf(logFilePattern, time.Now().Format(time.DateOnly))
 	filePath := filepath.Join(r.folder, filename)
 

--- a/internal/core/rotationengine/utils_test.go
+++ b/internal/core/rotationengine/utils_test.go
@@ -1,0 +1,755 @@
+package rotationengine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestGetFileDate(t *testing.T) {
+	folderName := "utils_getfiledate"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should return a error when the file can not parse the time", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		fileName := fmt.Sprintf(logFilePattern, "helloworld")
+
+		_, err := _r.getFileDate(fileName)
+		if err == nil {
+			t.Error("expected a error, but got nil")
+		}
+	})
+
+	t.Run("should return the correct time", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		expectedTime := time.Now().Format(time.DateOnly)
+		fileName := fmt.Sprintf(logFilePattern, expectedTime)
+
+		gotTime, err := _r.getFileDate(fileName)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+		if gotTime.Format(time.DateOnly) != expectedTime {
+			t.Errorf("expected time to be %q, but got %q", expectedTime, gotTime.Format(time.DateOnly))
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestGetAllFiles(t *testing.T) {
+	folderName := "utils_getallfiles"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should failure when the folder not set", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		_r.folder = ""
+
+		files, err := _r.getAllfiles()
+
+		if err == nil {
+			t.Error("expected a error, but got nil")
+		}
+		if files != nil {
+			t.Errorf("expected no files, but got %q", files)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should return only the log file names", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		wrongLogFile := "helloWorld.log"
+		_, err := os.OpenFile(filepath.Join(_r.folder, wrongLogFile), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		otherFile := "ionlog.txt"
+		_, err = _r.OpenFile(filepath.Join(_r.folder, otherFile), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		otherFolder := "ionic_health"
+		_ = os.Mkdir(filepath.Join(_r.folder, otherFolder), 0666)
+
+		files, err := _r.getAllfiles()
+
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		expectedTime := time.Now().Format(time.DateOnly)
+		expectFileName := fmt.Sprintf(logFilePattern, expectedTime)
+
+		if !slices.Contains(files, expectFileName) {
+			t.Errorf("expected the folder contains %q, but got %q", expectFileName, files)
+		}
+		if slices.Contains(files, wrongLogFile) {
+			t.Errorf("expected the function no return %q, but got", wrongLogFile)
+		}
+		if slices.Contains(files, otherFile) {
+			t.Errorf("expected the function no return %q, but got", otherFile)
+		}
+		if slices.Contains(files, otherFolder) {
+			t.Errorf("expected the function no return %q, but got", otherFile)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestGetMostRecentLogFile(t *testing.T) {
+	folderName := "utils_getmostrecentlogfile"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should failure when the folder not set", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		_r.folder = ""
+
+		file, err := _r.getMostRecentLogFile()
+		if err == nil {
+			t.Error("expected a error, but got nil")
+		}
+		if file != "" {
+			t.Errorf("expected no file, but got %q", file)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should return a error when the folder do not have log files", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		files, err := os.ReadDir(_r.folder)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		for _, file := range files {
+			err = os.Remove(filepath.Join(_r.folder, file.Name()))
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		}
+
+		file, err := _r.getMostRecentLogFile()
+		if err != ErrNoLogFileFound {
+			t.Errorf("expected error to be %q, but got %q", ErrNoLogFileFound, err)
+		}
+		if file != "" {
+			t.Errorf("expected no file, but got %q", file)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should return the most recent log file", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		fileName := fmt.Sprintf(logFilePattern, "2000-01-01")
+		_ = os.NewFile(0666, filepath.Join(_r.folder, fileName))
+		fileName = fmt.Sprintf(logFilePattern, "helloworld")
+		_ = os.NewFile(0666, filepath.Join(_r.folder, fileName))
+
+		filename := fmt.Sprintf(logFilePattern, time.Now().Format(time.DateOnly))
+
+		file, err := _r.getMostRecentLogFile()
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+		if file != filename {
+			t.Errorf("expected most recent log file to be %q, but got %q", filename, file)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestCreateNewFile(t *testing.T) {
+	folderName := "utils_createnewfile"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should failure when the folder not set", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		files, err := os.ReadDir(_r.folder)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		for _, file := range files {
+			err = os.Remove(filepath.Join(_r.folder, file.Name()))
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		}
+
+		_r.logFile = nil
+		_r.folder = ""
+
+		_r.createNewFile()
+
+		filename := fmt.Sprintf(logFilePattern, time.Now().Format(time.DateOnly))
+
+		files, err = os.ReadDir(folderName)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		var filenames = make([]string, 0, len(files))
+		for _, file := range files {
+			filenames = append(filenames, file.Name())
+		}
+
+		if slices.Contains(filenames, filename) {
+			t.Errorf("expected the file %q do not exist on the folder", filename)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should create a new log file", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		files, err := os.ReadDir(_r.folder)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		for _, file := range files {
+			err = os.Remove(filepath.Join(_r.folder, file.Name()))
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		}
+
+		_r.logFile = nil
+
+		_r.createNewFile()
+
+		if _r.logFile == nil {
+			t.Error("expected log file to be set, but is nil")
+		}
+
+		expectedFileName := fmt.Sprintf(logFilePattern, time.Now().Format(time.DateOnly))
+
+		file, err := _r.getMostRecentLogFile()
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+		if file != expectedFileName {
+			t.Errorf("expected most recent log file to be %q, but got %q", expectedFileName, file)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestAssertFolder(t *testing.T) {
+	folderName := "utils_assertfolder"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should return nil when the folder exists", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		if err := _r.assertFolder(); err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should create a folder when does not exists", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		if err := _r.assertFolder(); err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestCheckRotation(t *testing.T) {
+	folderName := "utils_checkrotation"
+	maxFolderSize := GB
+
+	t.Run("should return true when need rotate for daily rotation", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, Daily)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		t.Run("different year", func(t *testing.T) {
+			dateStr := "2000-01-01"
+			fileDate, err := time.Parse(time.DateOnly, dateStr)
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+
+			if !_r.checkRotation(fileDate) {
+				t.Error("expected the return to be true, but got false")
+			}
+		})
+
+		t.Run("same year but different month", func(t *testing.T) {
+			timeNow := time.Now()
+			month := timeNow.Month()
+			if month == 12 {
+				month -= 1
+			} else {
+				month += 1
+			}
+			fileDate := time.Date(timeNow.Year(), month, 1, 0, 0, 0, 0, time.UTC)
+
+			if !_r.checkRotation(fileDate) {
+				t.Error("expected the return to be true, but got false")
+			}
+		})
+
+		t.Run("same year and month but different day", func(t *testing.T) {
+			timeNow := time.Now()
+			day := timeNow.Day()
+			if day >= 28 {
+				day -= 1
+			} else {
+				day += 1
+			}
+			fileDate := time.Date(timeNow.Year(), timeNow.Month(), day, 0, 0, 0, 0, time.UTC)
+
+			if !_r.checkRotation(fileDate) {
+				t.Error("expected the return to be true, but got false")
+			}
+		})
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should return false when not need rotate for daily rotation", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, Daily)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		if _r.checkRotation(time.Now()) {
+			t.Error("expected the return to be false, but got true")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should return true when need rotate for weekly rotation", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, Daily)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		t.Run("different year", func(t *testing.T) {
+			dateStr := "2000-01-01"
+			fileDate, err := time.Parse(time.DateOnly, dateStr)
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+
+			if !_r.checkRotation(fileDate) {
+				t.Error("expected the return to be true, but got false")
+			}
+		})
+
+		t.Run("same year but different week", func(t *testing.T) {
+			timeNow := time.Now()
+			y, w := timeNow.UTC().ISOWeek()
+			if w >= 52 {
+				w -= 1
+			} else {
+				w += 1
+			}
+
+			firstDay := time.Date(y, time.January, 1, 0, 0, 0, 0, time.UTC)
+			dayWeek := int(firstDay.Weekday())
+			if dayWeek == 0 {
+				dayWeek = 7
+			}
+			fitDay := 1 - dayWeek
+			firstDay = firstDay.AddDate(0, 0, fitDay)
+
+			fileDate := firstDay.AddDate(0, 0, w*7)
+
+			if !_r.checkRotation(fileDate) {
+				t.Error("expected the return to be true, but got false")
+			}
+		})
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should return false when not need rotate for weekly rotation", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, Weekly)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		if _r.checkRotation(time.Now()) {
+			t.Error("expected the return to be false, but got true")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should return true when need rotate for weekly rotation", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, Monthly)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		t.Run("different year", func(t *testing.T) {
+			dateStr := "2000-01-01"
+			fileDate, err := time.Parse(time.DateOnly, dateStr)
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+
+			if !_r.checkRotation(fileDate) {
+				t.Error("expected the return to be true, but got false")
+			}
+		})
+
+		t.Run("same year but different month", func(t *testing.T) {
+			timeNow := time.Now()
+			month := timeNow.Month()
+			if month == 12 {
+				month -= 1
+			} else {
+				month += 1
+			}
+			fileDate := time.Date(timeNow.Year(), month, 1, 0, 0, 0, 0, time.UTC)
+
+			if !_r.checkRotation(fileDate) {
+				t.Error("expected the return to be true, but got false")
+			}
+		})
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+
+	})
+
+	t.Run("should return false when not need rotate for weekly rotation", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, Weekly)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		t.Run("same year and month but different day", func(t *testing.T) {
+			timeNow := time.Now()
+			day := timeNow.Day()
+			if day >= 28 {
+				day -= 1
+			} else {
+				day += 1
+			}
+			fileDate := time.Date(timeNow.Year(), timeNow.Month(), day, 0, 0, 0, 0, time.UTC)
+
+			if _r.checkRotation(fileDate) {
+				t.Error("expected the return to be true, but got false")
+			}
+		})
+
+		t.Run("same day", func(t *testing.T) {
+			if _r.checkRotation(time.Now()) {
+				t.Error("expected the return to be false, but got true")
+			}
+		})
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestGetOldestLogFile(t *testing.T) {
+	folderName := "utils_getolderlogfile"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should failure when the folder not exist", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+
+		if _, err := _r.getOldestLogFile(); err == nil {
+			t.Error("expected a error, but got nil")
+		}
+	})
+
+	t.Run("should return the error when no exist log files", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		files, err := os.ReadDir(_r.folder)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		for _, file := range files {
+			err = os.Remove(filepath.Join(_r.folder, file.Name()))
+			if err != nil {
+				t.Errorf("expected no error, but got %q", err)
+			}
+		}
+
+		if _, err := _r.getOldestLogFile(); err != ErrNoLogFileFound {
+			t.Errorf("expected error to be %q, but got %q", ErrNoLogFileFound, err)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should return the oldest lof file", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		expectedOldestFile := fmt.Sprintf(logFilePattern, "2000-01-01")
+		filePath := filepath.Join(_r.folder, expectedOldestFile)
+		_, err := _r.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+
+		oldestFile, err := _r.getOldestLogFile()
+		if err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+		if oldestFile != expectedOldestFile {
+			t.Errorf("expected the oldest log file to be %q, but got %q", expectedOldestFile, oldestFile)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestGetFolderSize(t *testing.T) {
+	folderName := "utils_getfoldersize"
+	maxFolderSize := GB
+	rotation := Daily
+
+	t.Run("should failure when the folder not exist", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+
+		if _, err := _r.getFolderSize(); err == nil {
+			t.Error("expected a error, but got nil")
+		}
+	})
+
+	t.Run("should return the folder size", func(t *testing.T) {
+		r := NewRotationEngine(folderName, maxFolderSize, rotation)
+		_r, ok := r.(*rotationEngine)
+		if !ok {
+			t.Fatal("NewRotationEngine() did not return a instance of rotation engine")
+		}
+
+		size, err := _r.getFolderSize()
+		if err != nil {
+			t.Error("expected a error, but got nil")
+		}
+		if size != 0 {
+			t.Errorf("expected error to be 0, but got %d", size)
+		}
+
+		if _, err = _r.logFile.Write([]byte("Hello World")); err != nil {
+			t.Errorf("expected no error, but got %q", err)
+		}
+		size, err = _r.getFolderSize()
+		if err != nil {
+			t.Error("expected a error, but got nil")
+		}
+		if size != 11 {
+			t.Errorf("expected error to be 11, but got %d", size)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a folder %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}

--- a/internal/core/runtimeinfo/runtimeinfo_test.go
+++ b/internal/core/runtimeinfo/runtimeinfo_test.go
@@ -79,6 +79,26 @@ func TestGetCallerInfo(t *testing.T) {
 			t.Errorf("function name should not be empty")
 		}
 	})
+
+	t.Run("should return empty caller info when skip is more than function on stack", func(t *testing.T) {
+		info := GetCallerInfo(5)
+
+		if info.File != "" {
+			t.Errorf("expected file to be empty, but got %q", info.File)
+		}
+
+		if info.Package != "" {
+			t.Errorf("expected package to be empty, but got %q", info.Package)
+		}
+
+		if info.Function != "" {
+			t.Errorf("expected function to be empty, but got %q", info.Function)
+		}
+
+		if info.Line != 0 {
+			t.Errorf("expected line to be 0, but got %q", info.Line)
+		}
+	})
 }
 
 func exampleFunction() CallerInfo {

--- a/internal/infrastructure/filesystem/filesystem_test.go
+++ b/internal/infrastructure/filesystem/filesystem_test.go
@@ -1,0 +1,101 @@
+package filesystem
+
+import (
+	"os"
+	"testing"
+)
+
+type mockOS struct{}
+
+func (m *mockOS) Stat(string) (os.FileInfo, error) {
+	return nil, nil
+}
+
+func (m *mockOS) Mkdir(string, os.FileMode) error {
+	return nil
+}
+
+func (m *mockOS) ReadDir(string) ([]os.DirEntry, error) {
+	return nil, nil
+}
+
+func (m *mockOS) IsNotExist(error) bool {
+	return true
+}
+
+func (m *mockOS) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return nil, nil
+}
+
+func (m *mockOS) RemoveFile(name string) error {
+	return nil
+}
+
+func TestFileSystem(t *testing.T) {
+	t.Run("should received the same functions", func(t *testing.T) {
+		m := &mockOS{}
+
+		fs := NewFileSystem(
+			m.Stat,
+			m.Mkdir,
+			m.ReadDir,
+			m.IsNotExist,
+			m.OpenFile,
+			m.RemoveFile,
+		)
+
+		if fs.Stat == nil {
+			t.Error("expected Stat function to be set, but got nil")
+			return
+		}
+
+		if file, err := fs.Stat("hello world"); file != nil && err != nil {
+			t.Errorf("expected return file=nil and err=nil of Stat function, but got file=%q and err=%q", file, err)
+		}
+
+		if fs.Mkdir == nil {
+			t.Error("expected Mkdir function to be set, but got nil")
+			return
+		}
+
+		if err := fs.Mkdir("hello world", 0777); err != nil {
+			t.Errorf("expected return err=nil of Mkdir function, but got err=%q", err)
+		}
+
+		if fs.ReadDir == nil {
+			t.Error("expected ReadDir function to be set, but got nil")
+			return
+		}
+
+		if dir, err := fs.ReadDir("hello world"); dir != nil && err != nil {
+			t.Errorf("expected return dir=nil and err=nil, but got dir=%q and err=%q", dir, err)
+		}
+
+		if fs.IsNotExist == nil {
+			t.Error("expected IsNotExist function to be set, but got nil")
+			return
+		}
+
+		if b := fs.IsNotExist(nil); b != true {
+			t.Errorf("expected return b=true of IsNotExist function, but got b='%v'", b)
+		}
+
+		if fs.OpenFile == nil {
+			t.Error("expected OpenFile function to be set, but got nil")
+			return
+		}
+
+		if file, err := fs.OpenFile("hello world", 0, 0777); file != nil && err != nil {
+			t.Errorf("expected return file=nil and err=nil OpenFile, but got file=%v and err=%q", file, err)
+		}
+
+		if fs.RemoveFile == nil {
+			t.Error("expected RemoveFile function to be set, but got nil")
+			return
+		}
+
+		if err := fs.RemoveFile("hello world"); err != nil {
+			t.Errorf("expected return err=nil of RemoveFile, but got err=%q", err)
+		}
+	})
+}

--- a/internal/infrastructure/memory/hashtable_test.go
+++ b/internal/infrastructure/memory/hashtable_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"testing"
+	"time"
 )
 
 func TestNewRecordMemory(t *testing.T) {
@@ -53,23 +54,51 @@ func TestGenHash(t *testing.T) {
 }
 
 func TestAddRecord(t *testing.T) {
+	msg := "test"
+	msgHash := GenHash(msg)
+
 	t.Run("Simple Add", func(t *testing.T) {
 		r := NewRecordMemory()
-		err := r.AddRecord(1, "test")
-		if err != nil {
+		_r, ok := r.(*recordMemory)
+		if !ok {
+			t.Fatal("NewRecordMemory did not returned a instace of record memory")
+		}
+
+		if err := r.AddRecord(1, msg); err != nil {
 			t.Errorf("AddRecord() failed")
+		}
+
+		if _r.records[1] == nil {
+			t.Error("exected readRecord return a instace of record unity, but got nil")
+			return
+		}
+
+		if _r.records[1].MsgHash != msgHash {
+			t.Errorf("expected message hash to be %q, but got %q", msgHash, _r.records[1].MsgHash)
 		}
 	})
 
 	t.Run("Collision Check", func(t *testing.T) {
 		r := NewRecordMemory()
-		err := r.AddRecord(1, "test")
-		if err != nil {
+		_r, ok := r.(*recordMemory)
+		if !ok {
+			t.Fatal("NewRecordMemory did not returned a instace of record memory")
+		}
+
+		if err := r.AddRecord(1, msg); err != nil {
 			t.Errorf("AddRecord() failed")
 		}
 
-		err = r.AddRecord(1, "test")
-		if err != ErrRecordIDCollision {
+		if _r.records[1] == nil {
+			t.Error("exected readRecord return a instace of record unity, but got nil")
+			return
+		}
+
+		if _r.records[1].MsgHash != msgHash {
+			t.Errorf("expected message hash to be %q, but got %q", msgHash, _r.records[1].MsgHash)
+		}
+
+		if err := r.AddRecord(1, msg); err != ErrRecordIDCollision {
 			t.Errorf("AddRecord() failed; Expected collision error")
 		}
 	})
@@ -94,45 +123,207 @@ func TestRemoveRecord(t *testing.T) {
 }
 
 func TestGetRecord(t *testing.T) {
-	t.Run("GetRecord", func(t *testing.T) {
+	t.Run("should return the interface of record unity", func(t *testing.T) {
 		r := NewRecordMemory()
 		r.AddRecord(1, "")
 		if r.GetRecord(1) == nil {
-			t.Errorf("GetRecord() failed")
+			t.Error("expected GetRecord() return a interface of record unity, but got nil")
+		}
+	})
+
+	t.Run("should return nil when unity do not exist", func(t *testing.T) {
+		r := NewRecordMemory()
+
+		if r.GetRecord(1) != nil {
+			t.Error("expected GetRecord() return nil, but got a interface")
 		}
 	})
 }
 
 func TestReadRecord(t *testing.T) {
+	msg := "hello world"
+	msgHash := GenHash(msg)
+
 	t.Run("ReadRecord", func(t *testing.T) {
 		_r := NewRecordMemory()
-		r := _r.(*recordMemory)
-		r.AddRecord(1, "")
-		if r.readRecord(1) == nil {
-			t.Errorf("readRecord() failed")
+		r, ok := _r.(*recordMemory)
+		if !ok {
+			t.Fatal("NewRecordMemory did not returned a instace of record memory")
+		}
+
+		r.records[1] = &recordUnity{MsgHash: msgHash}
+		u := r.readRecord(1)
+
+		if u == nil {
+			t.Error("exected readRecord return a instace of record unity, but got nil")
+			return
+		}
+
+		if u.MsgHash != msgHash {
+			t.Errorf("expected message hash to be %q, but got %q", msgHash, u.MsgHash)
+		}
+	})
+
+	t.Run("should timeout when mutex is locked", func(t *testing.T) {
+		_r := NewRecordMemory()
+		r, ok := _r.(*recordMemory)
+		if !ok {
+			t.Fatal("NewRecordMemory did not returned a instace of record memory")
+		}
+
+		r.records[1] = &recordUnity{MsgHash: msgHash}
+
+		r.mu.Lock()
+		comm := make(chan *recordUnity, 1)
+		go func(chan *recordUnity) {
+			comm <- r.readRecord(1)
+		}(comm)
+
+		select {
+		case <-comm:
+			t.Error("expected no receive a instance of record unity")
+		case <-time.After(500 * time.Microsecond):
+		}
+
+		r.mu.Unlock()
+		select {
+		case u := <-comm:
+			if u == nil {
+				t.Error("exected readRecord return a instace of record unity, but got nil")
+				return
+			}
+
+			if u.MsgHash != msgHash {
+				t.Errorf("expected message hash to be %q, but got %q", msgHash, u.MsgHash)
+			}
+		case <-time.After(500 * time.Microsecond):
+			t.Error("expected receive a instance of record unity, but timeout")
 		}
 	})
 }
 
 func TestWriteRecord(t *testing.T) {
-	t.Run("WriteRecord", func(t *testing.T) {
+	msg := "hello world"
+	msgHash := GenHash(msg)
+
+	t.Run("should write the record unity on record", func(t *testing.T) {
 		_r := NewRecordMemory()
-		r := _r.(*recordMemory)
-		r.writeRecord(1, &recordUnity{})
-		if r.records[1] == nil {
-			t.Errorf("writeRecord() failed")
+		r, ok := _r.(*recordMemory)
+		if !ok {
+			t.Fatal("NewRecordMemory did not returned a instace of record memory")
+		}
+
+		r.writeRecord(1, &recordUnity{MsgHash: msgHash})
+		u := r.records[1]
+
+		if u == nil {
+			t.Error("expected writeRecord() set a record unity on records")
+			return
+		}
+
+		if u.MsgHash != msgHash {
+			t.Errorf("expected message hash to be %q, but got %q", msgHash, u.MsgHash)
+		}
+	})
+
+	t.Run("should timeout when mutex is locked", func(t *testing.T) {
+		_r := NewRecordMemory()
+		r, ok := _r.(*recordMemory)
+		if !ok {
+			t.Fatal("NewRecordMemory did not returned a instace of record memory")
+		}
+
+		r.mu.Lock()
+		go func() {
+			r.writeRecord(1, &recordUnity{MsgHash: msgHash})
+		}()
+
+		time.Sleep(500 * time.Microsecond)
+		if u := r.records[1]; u != nil {
+			t.Error("expected unity record to be nil, but got a instace")
+		}
+
+		r.mu.Unlock()
+		time.Sleep(500 * time.Microsecond)
+
+		r.mu.Lock()
+		u := r.records[1]
+		r.mu.Unlock()
+
+		if u == nil {
+			t.Error("expected writeRecord() set a record unity on records")
+			return
+		}
+
+		if u.MsgHash != msgHash {
+			t.Errorf("expected message hash to be %q, but got %q", msgHash, u.MsgHash)
 		}
 	})
 }
 
 func TestDeleteRecord(t *testing.T) {
-	t.Run("DeleteRecord", func(t *testing.T) {
+	msg := "hello world"
+	msgHash := GenHash(msg)
+
+	t.Run("should delete the record unity on record", func(t *testing.T) {
 		_r := NewRecordMemory()
-		r := _r.(*recordMemory)
-		r.AddRecord(1, "")
+		r, ok := _r.(*recordMemory)
+		if !ok {
+			t.Fatal("NewRecordMemory did not returned a instace of record memory")
+		}
+
+		r.records[1] = &recordUnity{MsgHash: msgHash}
+
+		u := r.records[1]
+		if u == nil {
+			t.Error("expected set a record unity on records")
+			return
+		}
+		if u.MsgHash != msgHash {
+			t.Errorf("expected message hash to be %q, but got %q", msgHash, u.MsgHash)
+		}
+
 		r.deleteRecord(1)
 		if r.records[1] != nil {
-			t.Errorf("deleteRecord() failed")
+			t.Error("expected the record unity to be nil after delete")
 		}
+	})
+
+	t.Run("should timeout when mutex is locked", func(t *testing.T) {
+		_r := NewRecordMemory()
+		r, ok := _r.(*recordMemory)
+		if !ok {
+			t.Fatal("NewRecordMemory did not returned a instace of record memory")
+		}
+
+		r.records[1] = &recordUnity{MsgHash: msgHash}
+
+		u := r.records[1]
+		if u == nil {
+			t.Error("expected set a record unity on records")
+			return
+		}
+		if u.MsgHash != msgHash {
+			t.Errorf("expected message hash to be %q, but got %q", msgHash, u.MsgHash)
+		}
+
+		r.mu.Lock()
+		go func() {
+			r.deleteRecord(1)
+		}()
+
+		time.Sleep(10 * time.Microsecond)
+		if u := r.records[1]; u == nil {
+			t.Error("expected get a record unity instace, but got nil")
+		}
+
+		r.mu.Unlock()
+		time.Sleep(10 * time.Microsecond)
+
+		r.mu.Lock()
+		if r.records[1] != nil {
+			t.Error("expected the record unity to be nil after delete")
+		}
+		r.mu.Unlock()
 	})
 }

--- a/internal/service/core.go
+++ b/internal/service/core.go
@@ -19,6 +19,8 @@ type coreService struct {
 
 	logEngine       logengine.ILogger
 	rotationService IRotationService
+
+	serviceStatusLock sync.Mutex
 }
 
 type ICoreService interface {
@@ -91,9 +93,13 @@ func (c *coreService) Stop() {
 
 // Status returns the status of the logger service
 func (c *coreService) Status() ServiceStatus {
+	c.serviceStatusLock.Lock()
+	defer c.serviceStatusLock.Unlock()
 	return c.serviceStatus
 }
 
 func (c *coreService) setServiceStatus(status ServiceStatus) {
+	c.serviceStatusLock.Lock()
+	defer c.serviceStatusLock.Unlock()
 	c.serviceStatus = status
 }

--- a/internal/service/core.go
+++ b/internal/service/core.go
@@ -40,6 +40,11 @@ func (c *coreService) LogEngine() logengine.ILogger {
 }
 
 func (c *coreService) CreateRotationService(folder string, maxFolderSize uint, rotation rotationengine.PeriodicRotation) {
+	if c.rotationService != nil {
+		c.LogEngine().Writer().DeleteWriter(c.rotationService.RotationEngine())
+		c.rotationService.Stop()
+	}
+
 	c.rotationService = NewRotationService(folder, maxFolderSize, rotation)
 	c.LogEngine().Writer().AddWriter(c.rotationService.RotationEngine())
 }

--- a/internal/service/core_test.go
+++ b/internal/service/core_test.go
@@ -1,0 +1,425 @@
+package service
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IonicHealthUsa/ionlog/internal/core/logengine"
+	"github.com/IonicHealthUsa/ionlog/internal/core/rotationengine"
+	"github.com/IonicHealthUsa/ionlog/internal/core/runtimeinfo"
+)
+
+func TestNewCoreService(t *testing.T) {
+	t.Run("should return the core service", func(t *testing.T) {
+		cs := NewCoreService()
+		if cs == nil {
+			t.Error("expected core service no to be nil")
+		}
+		if reflect.ValueOf(cs).IsNil() {
+			t.Error("expected core service no to be nil")
+		}
+
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Error("expected a instance of core service to implement ICoreService")
+		}
+
+		if _cs.serviceStatus != 0 {
+			t.Errorf("expected service status to be '0', but got %q", _cs.serviceStatus)
+		}
+
+		if reflect.ValueOf(_cs.logEngine).IsNil() {
+			t.Error("expected log engine no to be nil")
+		}
+
+		if _cs.rotationService != nil {
+			t.Error("expected rotation service to be nil, but got a instance")
+		}
+
+		if reflect.ValueOf(cs.LogEngine()).IsNil() {
+			t.Error("expected the log engine interface no to be nil")
+		}
+	})
+}
+
+func TestLogEngine(t *testing.T) {
+	t.Run("should return a interface of logger", func(t *testing.T) {
+		cs := NewCoreService()
+
+		logger := cs.LogEngine()
+
+		if logger == nil {
+			t.Errorf("expected a interface of logger")
+		}
+
+		if reflect.ValueOf(logger).IsNil() {
+			t.Errorf("expected a interface of logger")
+		}
+	})
+
+	t.Run("should return a nil interface of logger when logger is not instanced", func(t *testing.T) {
+		cs := &coreService{}
+
+		logger := cs.LogEngine()
+
+		if logger != nil {
+			t.Errorf("expected a nil interface of logger")
+		}
+	})
+}
+
+func TestCreateRotationService(t *testing.T) {
+	folderName := "hello_world"
+	t.Run("should add a writer", func(t *testing.T) {
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Fatal("expected a instance of core service to implement ICoreService")
+		}
+
+		cs.CreateRotationService(folderName, 10, rotationengine.Daily)
+
+		if _cs.rotationService == nil {
+			t.Error("expected a interface of rotation service")
+		}
+
+		if reflect.ValueOf(_cs.rotationService).IsNil() {
+			t.Error("expected a interface of rotation service")
+		}
+
+		_r, ok := _cs.rotationService.(*rotationService)
+		if !ok {
+			t.Fatal("expected a instance of rotation service")
+		}
+
+		if _r.rotationEngine == nil {
+			t.Error("expected a interface of ratation engine")
+		}
+
+		if reflect.ValueOf(_r.rotationEngine).IsNil() {
+			t.Error("expected a interface of rotation engine")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a directory, but did not exist")
+		}
+
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+type mockBufferWriter struct {
+	lock sync.Mutex
+	cond *sync.Cond
+	buf  bytes.Buffer
+}
+
+func newMockBufferWriter() *mockBufferWriter {
+	m := &mockBufferWriter{}
+	m.cond = sync.NewCond(&m.lock)
+
+	return m
+}
+
+func (m *mockBufferWriter) Write(p []byte) (n int, err error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.cond.Signal()
+	return m.buf.Write(p)
+}
+
+func (m *mockBufferWriter) String() string {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	for m.buf.Len() == 0 {
+		m.cond.Wait()
+	}
+
+	return m.buf.String()
+}
+
+func (m *mockBufferWriter) Len() int {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.buf.Len()
+}
+
+func TestStart_Core(t *testing.T) {
+	r := logengine.Report{
+		Time:       time.Now().Format(time.RFC3339),
+		Level:      logengine.Info,
+		Msg:        "Hello World",
+		CallerInfo: runtimeinfo.GetCallerInfo(1),
+	}
+
+	reportLog := fmt.Sprintf(`{"time":"%s","level":"%s","msg":"%s","file":"%s","package":"%s","function":"%s","line":"%d"}
+`, r.Time, r.Level, r.Msg, r.CallerInfo.File, r.CallerInfo.Package, r.CallerInfo.Function, r.CallerInfo.Line)
+
+	t.Run("should receive the message on buffer", func(t *testing.T) {
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Fatal("NewCoreService() did not return *coreService")
+		}
+
+		buf := newMockBufferWriter()
+		cs.LogEngine().Writer().AddWriter(buf)
+
+		startSync := sync.WaitGroup{}
+		startSync.Add(1)
+		go cs.Start(&startSync)
+
+		cs.LogEngine().AsyncReport(r)
+		startSync.Wait()
+
+		if buf.String() != reportLog {
+			t.Errorf("expected the report log to be %q, but got %q", reportLog, buf.String())
+		}
+
+		_cs.cancel()
+	})
+
+	t.Run("should ionlog started", func(t *testing.T) {
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Fatal("NewCoreService() did not return *coreService")
+		}
+
+		startSync := sync.WaitGroup{}
+		startSync.Add(1)
+		go cs.Start(&startSync)
+		startSync.Wait()
+
+		_cs.serviceStatusLock.Lock()
+		if _cs.serviceStatus != Running {
+			t.Errorf("expected the status of logger service to be %q, but got %q", Running, _cs.serviceStatus)
+		}
+		_cs.serviceStatusLock.Unlock()
+
+		_cs.cancel()
+	})
+
+	t.Run("should ionlog started with rotation service", func(t *testing.T) {
+		folderName := "rotaion_start"
+		maxFolderSize := rotationengine.GB
+		rotation := rotationengine.Daily
+
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Fatal("NewCoreService() did not return *coreService")
+		}
+
+		cs.CreateRotationService(folderName, maxFolderSize, rotation)
+		_rs, ok := _cs.rotationService.(*rotationService)
+		if !ok {
+			t.Fatal("NewRotationService() did not return *rotationService")
+		}
+
+		startSync := sync.WaitGroup{}
+		startSync.Add(1)
+		go cs.Start(&startSync)
+		startSync.Wait()
+
+		_cs.serviceStatusLock.Lock()
+		if _cs.serviceStatus != Running {
+			t.Errorf("expected the status of logger service to be %q, but got %q", Running, _cs.serviceStatus)
+		}
+		_cs.serviceStatusLock.Unlock()
+
+		_rs.serviceStatusLock.Lock()
+		if _rs.serviceStatus != Running {
+			t.Errorf("expected the status of rotation service to be %q, but got %q", Running, _rs.serviceStatus)
+		}
+		_rs.serviceStatusLock.Unlock()
+
+		_cs.cancel()
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should send the report after ionlog start", func(t *testing.T) {
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Fatal("NewCoreService() did not return *coreService")
+		}
+
+		buf := newMockBufferWriter()
+		cs.LogEngine().Writer().AddWriter(buf)
+
+		cs.LogEngine().AsyncReport(r)
+
+		if buf.Len() != 0 {
+			t.Errorf("expected the buffer length to be 0, but got %d", buf.Len())
+		}
+
+		startSync := sync.WaitGroup{}
+		startSync.Add(1)
+		go cs.Start(&startSync)
+		startSync.Wait()
+
+		if buf.String() != reportLog {
+			t.Errorf("expected the report log to be %q, but got %q", reportLog, buf.String())
+		}
+
+		_cs.cancel()
+	})
+}
+
+func TestStop_Core(t *testing.T) {
+	t.Run("should core service stop", func(t *testing.T) {
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Fatal("NreCoreService() did not return *coreService")
+		}
+
+		startSync := sync.WaitGroup{}
+		startSync.Add(1)
+		go cs.Start(&startSync)
+		startSync.Wait()
+
+		_cs.serviceStatusLock.Lock()
+		if _cs.serviceStatus != Running {
+			t.Errorf("expected the status of logger service to be %q, but got %q", Running, _cs.serviceStatus)
+		}
+		_cs.serviceStatusLock.Unlock()
+
+		cs.Stop()
+		time.Sleep(time.Millisecond)
+
+		_cs.serviceStatusLock.Lock()
+		if _cs.serviceStatus != Stopped {
+			t.Errorf("expected the status of logger service to be %q, but got %q", Stopped, _cs.serviceStatus)
+		}
+		_cs.serviceStatusLock.Unlock()
+	})
+
+	t.Run("should core service stop with rotaion service", func(t *testing.T) {
+		folderName := "rotaion_stop"
+		maxFolderSize := rotationengine.GB
+		rotation := rotationengine.Daily
+
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Fatal("NreCoreService() did not return *coreService")
+		}
+
+		cs.CreateRotationService(folderName, maxFolderSize, rotation)
+		_rs, ok := _cs.rotationService.(*rotationService)
+		if !ok {
+			t.Fatal("NewRotationService() did not return *rotationService")
+		}
+
+		startSync := sync.WaitGroup{}
+		startSync.Add(1)
+		go cs.Start(&startSync)
+		startSync.Wait()
+
+		_cs.serviceStatusLock.Lock()
+		if _cs.serviceStatus != Running {
+			t.Errorf("expected the status of logger service to be %q, but got %q", Running, _cs.serviceStatus)
+		}
+		_cs.serviceStatusLock.Unlock()
+
+		_rs.serviceStatusLock.Lock()
+		if _rs.serviceStatus != Running {
+			t.Errorf("expected the status of rotation service to be %q, but got %q", Running, _rs.serviceStatus)
+		}
+		_rs.serviceStatusLock.Unlock()
+
+		cs.Stop()
+		time.Sleep(time.Millisecond)
+
+		if _cs.serviceStatus != Stopped {
+			t.Errorf("expected the status of logger service to be %q, but got %q", Stopped, _cs.serviceStatus)
+		}
+		if _rs.serviceStatus != Stopped {
+			t.Errorf("expected the status of rotation service to be %q, but got %q", Stopped, _rs.serviceStatus)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestStatusCore(t *testing.T) {
+	t.Run("should return running status", func(t *testing.T) {
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Error("expected a instance of core service to implement ICoreService")
+		}
+
+		_cs.serviceStatus = Running
+
+		if cs.Status() != Running {
+			t.Errorf("expected status to be %q, but got %q", Running, cs.Status())
+		}
+	})
+
+	t.Run("should return stopped status", func(t *testing.T) {
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Error("expected a instance of core service to implement ICoreService")
+		}
+
+		_cs.serviceStatus = Stopped
+
+		if cs.Status() != Stopped {
+			t.Errorf("expected status to be %q, but got %q", Stopped, cs.Status())
+		}
+	})
+}
+
+func TestSetServiceStatus(t *testing.T) {
+	t.Run("should set runnig status on service status", func(t *testing.T) {
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Error("expected a instance of core service to implement ICoreService")
+		}
+
+		_cs.setServiceStatus(Running)
+
+		if _cs.serviceStatus != Running {
+			t.Errorf("expected service status to be %q, but got %q", Running, _cs.serviceStatus)
+		}
+	})
+
+	t.Run("should set stopped status on service status", func(t *testing.T) {
+		cs := NewCoreService()
+		_cs, ok := cs.(*coreService)
+		if !ok {
+			t.Error("expected a instance of core service to implement ICoreService")
+		}
+
+		_cs.setServiceStatus(Stopped)
+
+		if _cs.serviceStatus != Stopped {
+			t.Errorf("expected service status to be %q, but got %q", Stopped, _cs.serviceStatus)
+		}
+	})
+}

--- a/internal/service/rotation.go
+++ b/internal/service/rotation.go
@@ -18,6 +18,8 @@ type rotationService struct {
 	serviceStatus ServiceStatus
 
 	rotationEngine rotationengine.IRotationEngine
+
+	serviceStatusLock sync.Mutex
 }
 
 type IRotationService interface {
@@ -75,9 +77,13 @@ func (r *rotationService) Stop() {
 }
 
 func (r *rotationService) Status() ServiceStatus {
+	r.serviceStatusLock.Lock()
+	defer r.serviceStatusLock.Unlock()
 	return r.serviceStatus
 }
 
 func (r *rotationService) setServiceStatus(status ServiceStatus) {
+	r.serviceStatusLock.Lock()
+	defer r.serviceStatusLock.Unlock()
 	r.serviceStatus = status
 }

--- a/internal/service/rotation_test.go
+++ b/internal/service/rotation_test.go
@@ -1,0 +1,213 @@
+package service
+
+import (
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/IonicHealthUsa/ionlog/internal/core/rotationengine"
+)
+
+func TestNewRotationService(t *testing.T) {
+	folderName := "new_rotation_service"
+	maxFolderSizes := []uint{
+		rotationengine.NoMaxFolderSize,
+		rotationengine.KB,
+		rotationengine.MB,
+		rotationengine.GB,
+	}
+	rotations := []rotationengine.PeriodicRotation{
+		rotationengine.NoAutoRotate,
+		rotationengine.Daily,
+		rotationengine.Weekly,
+		rotationengine.Monthly,
+	}
+
+	t.Run("should return the rotation service", func(t *testing.T) {
+		for _, rotation := range rotations {
+			for _, maxFolderSize := range maxFolderSizes {
+				rs := NewRotationService(folderName, maxFolderSize, rotation)
+				if rs == nil {
+					t.Error("expected a interface of rotaion service")
+				}
+				if reflect.ValueOf(rs).IsNil() {
+					t.Error("expected a interface of rotation service")
+				}
+
+				_rs, ok := rs.(*rotationService)
+				if !ok {
+					t.Error("expected a instance of rotation service")
+				}
+
+				if _rs.rotationEngine == nil {
+					t.Error("expected a interface of rotation engine")
+				}
+				if reflect.ValueOf(_rs.rotationEngine).IsNil() {
+					t.Error("expected a interface of rotaion engine")
+				}
+
+				if _, err := os.Stat(folderName); err != nil {
+					t.Errorf("expected a direcory %q, but did not exist", folderName)
+				}
+				if err := os.RemoveAll(folderName); err != nil {
+					t.Error("expected remove all file and the directory")
+				}
+			}
+		}
+	})
+}
+
+func TestRotationService(t *testing.T) {
+	folderName := "rotaion_service"
+	maxFolderSize := rotationengine.GB
+	rotation := rotationengine.Daily
+
+	t.Run("should return the interface of rotation service", func(t *testing.T) {
+		rs := NewRotationService(folderName, maxFolderSize, rotation)
+		if rs == nil {
+			t.Error("expected a interface of rotaion service")
+		}
+		if reflect.ValueOf(rs).IsNil() {
+			t.Error("expected a interface of rotation service")
+		}
+
+		re := rs.RotationEngine()
+		if re == nil {
+			t.Error("expected a interface of rotation engine")
+		}
+		if reflect.ValueOf(re).IsNil() {
+			t.Error("expected a interface of rotation engine")
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestStart_rotatation(t *testing.T) {
+	folderName := "rotaion_start"
+	maxFolderSize := rotationengine.GB
+	rotation := rotationengine.Daily
+
+	t.Run("should start the rotate service", func(t *testing.T) {
+		rs := NewRotationService(folderName, maxFolderSize, rotation)
+		_rs, ok := rs.(*rotationService)
+		if !ok {
+			t.Error("expected a instance of rotation of rotation service")
+		}
+
+		startSync := &sync.WaitGroup{}
+		startSync.Add(1)
+		go rs.Start(startSync)
+		startSync.Wait()
+
+		_rs.serviceStatusLock.Lock()
+		if _rs.serviceStatus != Running {
+			t.Errorf("expected rotate service status to be %q, but got %q", Running, _rs.serviceStatus)
+		}
+		_rs.serviceStatusLock.Unlock()
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestStop_rotation(t *testing.T) {
+	folderName := "rotaion_stop"
+	maxFolderSize := rotationengine.GB
+	rotation := rotationengine.Daily
+
+	t.Run("should stop the rotate service", func(t *testing.T) {
+		rs := NewRotationService(folderName, maxFolderSize, rotation)
+		_rs, ok := rs.(*rotationService)
+		if !ok {
+			t.Error("expected a instance of rotation of rotation service")
+		}
+
+		startSync := &sync.WaitGroup{}
+		startSync.Add(1)
+		go rs.Start(startSync)
+		startSync.Wait()
+
+		_rs.serviceStatusLock.Lock()
+		if _rs.serviceStatus != Running {
+			t.Errorf("expected rotate service status to be %q, but got %q", Running, _rs.serviceStatus)
+		}
+		_rs.serviceStatusLock.Unlock()
+
+		rs.Stop()
+		time.Sleep(time.Millisecond)
+
+		if _rs.serviceStatus != Stopped {
+			t.Errorf("expected rotate service status to be %q, but got %q", Stopped, _rs.serviceStatus)
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}
+
+func TestStatusRotationService(t *testing.T) {
+	folderName := "status"
+	maxFolderSize := rotationengine.GB
+	rotation := rotationengine.Daily
+
+	t.Run("should return running status", func(t *testing.T) {
+		rs := NewRotationService(folderName, maxFolderSize, rotation)
+		_rs, ok := rs.(*rotationService)
+		if !ok {
+			t.Error("expected a instance of rotation of rotation service")
+		}
+
+		_rs.serviceStatus = Running
+
+		if rs.Status() != Running {
+			t.Errorf("expected staus to be %q, but got %q", Running, rs.Status())
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+
+	t.Run("should return stopped status", func(t *testing.T) {
+		rs := NewRotationService(folderName, maxFolderSize, rotation)
+
+		_rs, ok := rs.(*rotationService)
+		if !ok {
+			t.Error("expected a instance of rotation of rotation service")
+		}
+
+		_rs.serviceStatus = Stopped
+
+		if rs.Status() != Stopped {
+			t.Errorf("expected staus to be %q, but got %q", Stopped, rs.Status())
+		}
+
+		if _, err := os.Stat(folderName); err != nil {
+			t.Errorf("expected a direcory %q, but did not exist", folderName)
+		}
+
+		if err := os.RemoveAll(folderName); err != nil {
+			t.Error("expected remove all file and the directory")
+		}
+	})
+}

--- a/internal/usecases/custom_logs_test.go
+++ b/internal/usecases/custom_logs_test.go
@@ -1,40 +1,101 @@
 package usecases
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/IonicHealthUsa/ionlog/internal/infrastructure/memory"
 )
 
 func TestLogOnce(t *testing.T) {
-	t.Run("First Log", func(t *testing.T) {
+	t.Run("should return true when log a message", func(t *testing.T) {
 		r := memory.NewRecordMemory()
+
+		msgHash := memory.GenHash("pkg")
+
 		if !LogOnce(r, "pkg", "function", "file", "msg") {
 			t.Errorf("LogOnce() failed")
 		}
+
+		id := memory.GenHash(fmt.Sprintf("%s%s%s", "function", "file", "msg"))
+		rec := r.GetRecord(id)
+
+		if rec.GetMsgHash() != msgHash {
+			t.Errorf("expected hash message to be %q, but got %q", msgHash, rec.GetMsgHash())
+		}
 	})
 
-	t.Run("Two logs check same logs msg", func(t *testing.T) {
+	t.Run("should return false when two logs check same logs menssage for the same hash", func(t *testing.T) {
 		r := memory.NewRecordMemory()
 
+		msgHash := memory.GenHash("pkg")
+
 		if !LogOnce(r, "pkg", "function", "file", "msg") {
-			t.Errorf("LogOnce() failed")
+			t.Error("expected the return to be 'true', but got 'false'")
 		}
 
 		if LogOnce(r, "pkg", "function", "file", "msg") {
-			t.Errorf("LogOnce() failed")
+			t.Error("expected the return to be 'false', but got 'true'")
+		}
+
+		id := memory.GenHash(fmt.Sprintf("%s%s%s", "function", "file", "msg"))
+		rec := r.GetRecord(id)
+
+		if rec.GetMsgHash() != msgHash {
+			t.Errorf("expected hash message to be %q, but got %q", msgHash, rec.GetMsgHash())
 		}
 	})
 
-	t.Run("Two logs but new msg", func(t *testing.T) {
+	t.Run("should return true when set two different logs with same message", func(t *testing.T) {
+		r := memory.NewRecordMemory()
+
+		msgHash := memory.GenHash("pkg")
+
+		if !LogOnce(r, "pkg", "function", "file", "msg") {
+			t.Error("expected the return to be 'true', but got 'false'")
+		}
+		id1 := memory.GenHash(fmt.Sprintf("%s%s%s", "function", "file", "msg"))
+
+		if !LogOnce(r, "pkg", "function", "file", "New Msg") {
+			t.Error("expected the return to be 'true', but got 'false'")
+		}
+		id2 := memory.GenHash(fmt.Sprintf("%s%s%s", "function", "file", "New Msg"))
+
+		rec1 := r.GetRecord(id1)
+
+		if rec1.GetMsgHash() != msgHash {
+			t.Errorf("expected hash message to be %q, but got %q", msgHash, rec1.GetMsgHash())
+		}
+
+		rec2 := r.GetRecord(id2)
+
+		if rec2.GetMsgHash() != msgHash {
+			t.Errorf("expected hash message to be %q, but got %q", msgHash, rec2.GetMsgHash())
+		}
+	})
+
+	t.Run("should set the new message on the ready hash", func(t *testing.T) {
 		r := memory.NewRecordMemory()
 
 		if !LogOnce(r, "pkg", "function", "file", "msg") {
-			t.Errorf("LogOnce() failed")
+			t.Error("expected the return to be 'true', but got 'false'")
 		}
 
-		if !LogOnce(r, "pkg", "function", "file", "New Msg") {
-			t.Errorf("LogOnce() failed")
+		id := memory.GenHash(fmt.Sprintf("%s%s%s", "function", "file", "msg"))
+		rec := r.GetRecord(id)
+
+		msgHash := memory.GenHash("pkg")
+		if msgHash != rec.GetMsgHash() {
+			t.Errorf("expected hash to be %q, but got %q", msgHash, rec.GetMsgHash())
+		}
+
+		if !LogOnce(r, "gkp", "function", "file", "msg") {
+			t.Error("expected the return to be 'true', but got 'false'")
+		}
+
+		msgHash = memory.GenHash("gkp")
+		if msgHash != rec.GetMsgHash() {
+			t.Errorf("expected hash to be %q, but got %q", msgHash, rec.GetMsgHash())
 		}
 	})
 }

--- a/logger.go
+++ b/logger.go
@@ -11,6 +11,7 @@ import (
 	"github.com/IonicHealthUsa/ionlog/internal/usecases"
 )
 
+// Start begin the ionlog reports when it does not running
 func Start() {
 	startSync := sync.WaitGroup{}
 	startSync.Add(1)
@@ -18,6 +19,7 @@ func Start() {
 	startSync.Wait()
 }
 
+// Stop stop the ionlog reports and reset the logger
 func Stop() {
 	logger.Stop()
 	logger = service.NewCoreService() // Reset the logger
@@ -35,7 +37,8 @@ func Info(msg string) {
 	)
 }
 
-// Infof logs a message with level info. Arguments are handled in the manner of fmt.Printf.
+// Infof logs a message with level info.
+// Arguments are handled in the manner of fmt.Printf.
 func Infof(msg string, args ...any) {
 	logger.LogEngine().AsyncReport(
 		logengine.Report{
@@ -59,7 +62,8 @@ func Error(msg string) {
 	)
 }
 
-// Errorf logs a message with level error. Arguments are handled in the manner of fmt.Printf.
+// Errorf logs a message with level error.
+// Arguments are handled in the manner of fmt.Printf.
 func Errorf(msg string, args ...any) {
 	logger.LogEngine().AsyncReport(
 		logengine.Report{
@@ -83,7 +87,8 @@ func Warn(msg string) {
 	)
 }
 
-// Warnf logs a message with level warn. Arguments are handled in the manner of fmt.Printf.
+// Warnf logs a message with level warn.
+// Arguments are handled in the manner of fmt.Printf.
 func Warnf(msg string, args ...any) {
 	logger.LogEngine().AsyncReport(
 		logengine.Report{
@@ -107,7 +112,8 @@ func Debug(msg string) {
 	)
 }
 
-// Debugf logs a message with level debug. Arguments are handled in the manner of fmt.Printf.
+// Debugf logs a message with level debug.
+// Arguments are handled in the manner of fmt.Printf.
 func Debugf(msg string, args ...any) {
 	logger.LogEngine().AsyncReport(
 		logengine.Report{
@@ -119,6 +125,7 @@ func Debugf(msg string, args ...any) {
 	)
 }
 
+// Trace logs a message with level trace only when trace mode is enable.
 func Trace(msg string) {
 	if !logger.LogEngine().TraceMode() {
 		return
@@ -133,6 +140,8 @@ func Trace(msg string) {
 	)
 }
 
+// Tracef logs a message with level trace only when trace mode is enable.
+// Arguments are handled in the manner of fmt.Printf.
 func Tracef(msg string, args ...any) {
 	if !logger.LogEngine().TraceMode() {
 		return
@@ -147,38 +156,55 @@ func Tracef(msg string, args ...any) {
 	)
 }
 
+// LogOnceInfo logs a message with level info only once time.
 func LogOnceInfo(msg string) {
 	logOnce(logengine.Info, msg)
 }
 
+// LogOnceInfof logs a message with level info only once time.
+// Arguments are handled in the manner of fmt.Printf.
 func LogOnceInfof(msg string, args ...any) {
 	logOnce(logengine.Info, fmt.Sprintf(msg, args...))
 }
 
+// LogOnceError logs a message with level error only once time.
+// Arguments are handled in the manner of fmt.Printf.
 func LogOnceError(msg string) {
 	logOnce(logengine.Error, msg)
 }
 
+// LogOnceErrorf logs a message with level error only once time.
+// Arguments are handled in the manner of fmt.Printf.
 func LogOnceErrorf(msg string, args ...any) {
 	logOnce(logengine.Error, fmt.Sprintf(msg, args...))
 }
 
+// LogOnceWarn logs a message with level warn only once time.
+// Arguments are handled in the manner of fmt.Printf.
 func LogOnceWarn(msg string) {
 	logOnce(logengine.Warn, msg)
 }
 
+// LogOnceWarnf logs a message with level warn only once time.
+// Arguments are handled in the manner of fmt.Printf.
 func LogOnceWarnf(msg string, args ...any) {
 	logOnce(logengine.Warn, fmt.Sprintf(msg, args...))
 }
 
+// LogOnceDebug logs a message with level debug only once time.
+// Arguments are handled in the manner of fmt.Printf.
 func LogOnceDebug(msg string) {
 	logOnce(logengine.Debug, msg)
 }
 
+// LogOnceDebugf logs a message with level debug only once time.
+// Arguments are handled in the manner of fmt.Printf.
 func LogOnceDebugf(msg string, args ...any) {
 	logOnce(logengine.Debug, fmt.Sprintf(msg, args...))
 }
 
+// logOnce send the information about the function
+// which called the log level to report queue asynchronously.
 func logOnce(level logengine.Level, recordMsg string) {
 	callerInfo := runtimeinfo.GetCallerInfo(3)
 

--- a/logger_settings.go
+++ b/logger_settings.go
@@ -21,7 +21,14 @@ func SetAttributes(fns ...customAttrs) {
 // every log will be written to these targets.
 func WithWriters(w ...io.Writer) customAttrs {
 	return func(i service.ICoreService) {
-		i.LogEngine().Writer().SetWriters(w...)
+		i.LogEngine().Writer().AddWriter(w...)
+	}
+}
+
+// WithoutWriters deletes the write targets for the logger.
+func WithoutWriters(w ...io.Writer) customAttrs {
+	return func(i service.ICoreService) {
+		i.LogEngine().Writer().DeleteWriter(w...)
 	}
 }
 

--- a/logger_settings.go
+++ b/logger_settings.go
@@ -40,6 +40,14 @@ func WithStaticFields(attrs map[string]string) customAttrs {
 	}
 }
 
+// WithoutStaticFields remove the static fields for the logger.
+// Use the key of the static field to remove.
+func WithoutStaticFields(fields ...string) customAttrs {
+	return func(i service.ICoreService) {
+		i.LogEngine().DeleteStaticField(fields...)
+	}
+}
+
 // WithLogFileRotation enables log file rotation,
 // specifying the directory where log files will be stored,
 // the maximum size of the log folder in bytes, and the rotation frequency.

--- a/logger_settings.go
+++ b/logger_settings.go
@@ -1,9 +1,7 @@
 package ionlog
 
 import (
-	"fmt"
 	"io"
-	"os"
 
 	"github.com/IonicHealthUsa/ionlog/internal/core/rotationengine"
 	"github.com/IonicHealthUsa/ionlog/internal/service"
@@ -14,17 +12,13 @@ type customAttrs func(i service.ICoreService)
 // SetAttributes sets the log SetAttributes
 // fns is a variadic parameter that accepts customAttrs
 func SetAttributes(fns ...customAttrs) {
-	if logger.Status() == service.Running {
-		fmt.Fprint(os.Stderr, "Logger is already running, cannot set attributes\n")
-		return
-	}
-
 	for _, fn := range fns {
 		fn(logger)
 	}
 }
 
-// WithWriters sets the write targets for the logger, every log will be written to these targets.
+// WithWriters sets the write targets for the logger,
+// every log will be written to these targets.
 func WithWriters(w ...io.Writer) customAttrs {
 	return func(i service.ICoreService) {
 		i.LogEngine().Writer().SetWriters(w...)
@@ -39,20 +33,31 @@ func WithStaticFields(attrs map[string]string) customAttrs {
 	}
 }
 
-// WithLogFileRotation enables log file rotation, specifying the directory where log files will be stored, the maximum size of the log folder in bytes, and the rotation frequency.
-func WithLogFileRotation(folder string, folderMaxSize uint, period rotationengine.PeriodicRotation) customAttrs {
+// WithLogFileRotation enables log file rotation,
+// specifying the directory where log files will be stored,
+// the maximum size of the log folder in bytes, and the rotation frequency.
+func WithLogFileRotation(
+	folder string,
+	folderMaxSize uint,
+	period rotationengine.PeriodicRotation,
+) customAttrs {
 	return func(i service.ICoreService) {
 		i.CreateRotationService(folder, folderMaxSize, period)
 	}
 }
 
-func SetQueueSize(size uint) customAttrs {
+// WithQueueSize sets the size of the reports queue,
+// which stores logs before sending them to a file descriptor.
+func WithQueueSize(size uint) customAttrs {
 	return func(i service.ICoreService) {
 		i.LogEngine().SetReportQueueSize(size)
 	}
 }
 
-func SetTraceMode(mode bool) customAttrs {
+// WithTraceMode enables trace log mode.
+// For default, the trace mode is disable,
+// to enable is need pass a true boolean.
+func WithTraceMode(mode bool) customAttrs {
 	return func(i service.ICoreService) {
 		i.LogEngine().SetTraceMode(mode)
 	}


### PR DESCRIPTION
Refactor the wirter interface and ionlog settings.
- Remove set writers function and use only add writers function;
- Add the function delete writers;
- Change the logic of add static fields;
- Add function to remove static fields.
- Use mutex to access variable of the logger;
- Add test for the internals.
- Update the README.md