### PR TITLE
Feature caller stack depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ func main() {
 
 	ionlog.SetAttributes(
 		ionlog.WithStaticFields(appInfo),
-		ionlog.WithWriters(ionlog.CustomOutput),
+		ionlog.WithWriters(ionlog.CustomOutput(os.Stdout)),
+		ionlog.WithCallerInfoDepth(2), // default is 2
 	)
 
 	ionlog.Start()
@@ -61,6 +62,7 @@ func main() {
 		ionlog.WithWriters(ionlog.DefaultOutput),
 		// ionlog.WithLogFileRotation(ionlog.DefaultLogFolder, 1*ionlog.Mebibyte, ionlog.Daily),
 		ionlog.WithQueueSize(10),
+		ionlog.WithCallerInfoDepth(2), // default is 2
 	)
 
 	ionlog.Start()
@@ -96,6 +98,10 @@ func main() {
 	// Remove the static field
 	ionlog.SetAttributes(ionlog.WithoutStaticFields("id"))
 	ionlog.Info("This log does not have the static field 'id' anymore")
+
+	// Configure caller stack depth (useful when using wrapper functions)
+	ionlog.SetAttributes(ionlog.WithCallerInfoDepth(3))
+	ionlog.Info("This log uses a custom caller stack depth")
 }
 ```
 
@@ -149,6 +155,13 @@ ionlog.SetAttributes(
 ```go
 ionlog.SetAttributes(
     ionlog.WithTraceMode(true), // or false to disable
+)
+```
+
+### Caller Stack Depth: configure how many stack frames to skip when retrieving caller information.
+```go
+ionlog.SetAttributes(
+    ionlog.WithCallerInfoDepth(3), // default is 2
 )
 ```
 

--- a/internal/core/logengine/logger.go
+++ b/internal/core/logengine/logger.go
@@ -34,6 +34,9 @@ type logger struct {
 
 	reportLock sync.Mutex
 	closeLock  sync.Mutex
+
+	callerStackDepth     int
+	callerStackDepthLock sync.RWMutex
 }
 
 type ILogger interface {
@@ -48,6 +51,8 @@ type ILogger interface {
 	SetReportQueueSize(size uint)
 	SetTraceMode(mode bool)
 	TraceMode() bool
+	SetCallerStackDepth(depth int)
+	GetCallerStackDepth() int
 }
 
 func NewLogger() ILogger {
@@ -57,6 +62,7 @@ func NewLogger() ILogger {
 	logger.logsMemory = memory.NewRecordMemory()
 	logger.reports = make(chan ReportType, 100)
 	logger.writer = NewWriter()
+	logger.callerStackDepth = 2 // default depth
 
 	return logger
 }
@@ -177,4 +183,16 @@ func (l *logger) TraceMode() bool {
 	l.reportLock.Lock()
 	defer l.reportLock.Unlock()
 	return l.traceMode
+}
+
+func (l *logger) SetCallerStackDepth(depth int) {
+	l.callerStackDepthLock.Lock()
+	defer l.callerStackDepthLock.Unlock()
+	l.callerStackDepth = depth
+}
+
+func (l *logger) GetCallerStackDepth() int {
+	l.callerStackDepthLock.RLock()
+	defer l.callerStackDepthLock.RUnlock()
+	return l.callerStackDepth
 }

--- a/logger.go
+++ b/logger.go
@@ -37,7 +37,7 @@ func Info(msg string) {
 			Time:       time.Now().Format(time.RFC3339),
 			Level:      logengine.Info,
 			Msg:        msg,
-			CallerInfo: runtimeinfo.GetCallerInfo(2),
+			CallerInfo: runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth()),
 		},
 	)
 }
@@ -50,7 +50,7 @@ func Infof(msg string, args ...any) {
 			Time:       time.Now().Format(time.RFC3339),
 			Level:      logengine.Info,
 			Msg:        fmt.Sprintf(msg, args...),
-			CallerInfo: runtimeinfo.GetCallerInfo(2),
+			CallerInfo: runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth()),
 		},
 	)
 }
@@ -62,7 +62,7 @@ func Error(msg string) {
 			Time:       time.Now().Format(time.RFC3339),
 			Level:      logengine.Error,
 			Msg:        msg,
-			CallerInfo: runtimeinfo.GetCallerInfo(2),
+			CallerInfo: runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth()),
 		},
 	)
 }
@@ -75,7 +75,7 @@ func Errorf(msg string, args ...any) {
 			Time:       time.Now().Format(time.RFC3339),
 			Level:      logengine.Error,
 			Msg:        fmt.Sprintf(msg, args...),
-			CallerInfo: runtimeinfo.GetCallerInfo(2),
+			CallerInfo: runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth()),
 		},
 	)
 }
@@ -87,7 +87,7 @@ func Warn(msg string) {
 			Time:       time.Now().Format(time.RFC3339),
 			Level:      logengine.Warn,
 			Msg:        msg,
-			CallerInfo: runtimeinfo.GetCallerInfo(2),
+			CallerInfo: runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth()),
 		},
 	)
 }
@@ -100,7 +100,7 @@ func Warnf(msg string, args ...any) {
 			Time:       time.Now().Format(time.RFC3339),
 			Level:      logengine.Warn,
 			Msg:        fmt.Sprintf(msg, args...),
-			CallerInfo: runtimeinfo.GetCallerInfo(2),
+			CallerInfo: runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth()),
 		},
 	)
 }
@@ -112,7 +112,7 @@ func Debug(msg string) {
 			Time:       time.Now().Format(time.RFC3339),
 			Level:      logengine.Debug,
 			Msg:        msg,
-			CallerInfo: runtimeinfo.GetCallerInfo(2),
+			CallerInfo: runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth()),
 		},
 	)
 }
@@ -125,7 +125,7 @@ func Debugf(msg string, args ...any) {
 			Time:       time.Now().Format(time.RFC3339),
 			Level:      logengine.Debug,
 			Msg:        fmt.Sprintf(msg, args...),
-			CallerInfo: runtimeinfo.GetCallerInfo(2),
+			CallerInfo: runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth()),
 		},
 	)
 }
@@ -140,7 +140,7 @@ func Trace(msg string) {
 			Time:       time.Now().Format(time.RFC3339),
 			Level:      logengine.Trace,
 			Msg:        msg,
-			CallerInfo: runtimeinfo.GetCallerInfo(2),
+			CallerInfo: runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth()),
 		},
 	)
 }
@@ -156,7 +156,7 @@ func Tracef(msg string, args ...any) {
 			Time:       time.Now().Format(time.RFC3339),
 			Level:      logengine.Trace,
 			Msg:        fmt.Sprintf(msg, args...),
-			CallerInfo: runtimeinfo.GetCallerInfo(2),
+			CallerInfo: runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth()),
 		},
 	)
 }
@@ -211,7 +211,7 @@ func LogOnceDebugf(msg string, args ...any) {
 // logOnce send the information about the function
 // which called the log level to report queue asynchronously.
 func logOnce(level logengine.Level, recordMsg string) {
-	callerInfo := runtimeinfo.GetCallerInfo(3)
+	callerInfo := runtimeinfo.GetCallerInfo(logger.LogEngine().GetCallerStackDepth() + 1)
 
 	proceed := usecases.LogOnce(
 		logger.LogEngine().Memory(),

--- a/logger_settings.go
+++ b/logger_settings.go
@@ -79,3 +79,12 @@ func WithTraceMode(mode bool) customAttrs {
 		i.LogEngine().SetTraceMode(mode)
 	}
 }
+
+// WithCallerInfoDepth sets the caller stack depth for log functions.
+// The depth determines how many stack frames to skip when retrieving caller information.
+// Default depth is 2. For LogOnce functions, the depth is automatically increased by 1.
+func WithCallerInfoDepth(depth int) customAttrs {
+	return func(i service.ICoreService) {
+		i.LogEngine().SetCallerStackDepth(depth)
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds the ability to configure the caller stack depth used when retrieving caller information for log entries. This feature is particularly useful when using wrapper functions or when you need to adjust how many stack frames to skip to get the correct caller information.

## Changes

### Core Implementation
- **Added `callerStackDepth` field** to `logger` struct in `logengine` package with default value of 2 (maintains backward compatibility)
- **Implemented `SetCallerStackDepth(depth int)` and `GetCallerStackDepth() int`** methods in `ILogger` interface
- **Used `sync.RWMutex`** for thread-safe operations:
  - Multiple concurrent reads are allowed (non-blocking)
  - Writes block all reads and other writes
- **Added `WithCallerInfoDepth(depth int)`** configuration function following the existing pattern in `logger_settings.go`

### Code Updates
- Updated all log functions (`Info`, `Error`, `Warn`, `Debug`, `Trace`, and their `f` variants) in `logger.go` to use `LogEngine().GetCallerStackDepth()` instead of hardcoded value
- Updated `logOnce` function to automatically use `depth + 1` (since it's called from another function)

### Architecture
- Moved `callerStackDepth` implementation from `service` layer to `logengine` layer where it logically belongs
- This ensures the configuration is directly tied to the logger instance rather than the service wrapper

### Documentation
- Added `WithCallerInfoDepth` to configuration options section in README
- Updated Basic Usage and Advanced Usage examples to demonstrate the feature
- Added example showing dynamic configuration of caller stack depth

### Testing
- Comprehensive test suite in `logengine/logger_test.go` covering:
  - Default value validation (should be 2)
  - Set/Get functionality with multiple test cases
  - Concurrent reads without blocking (validates RWMutex behavior with 100 concurrent readers)
  - Thread-safety with concurrent writes (50 concurrent writers)
  - Consistency during mixed concurrent operations (reads and writes)
  - All tests use `NewLogger()` directly, testing the implementation at the correct layer

## Usage Example
```
ionlog.SetAttributes(
    ionlog.WithCallerInfoDepth(3), // Configure caller stack depth
)
```
## Benefits

- **Flexibility**: Allows adjustment of caller information when using wrapper functions or custom logging helpers
- **Performance**: RWMutex allows multiple concurrent reads without blocking, improving performance in high-concurrency scenarios
- **Thread-safe**: All operations are properly synchronized using RWMutex
- **Backward compatible**: Default value of 2 maintains existing behavior
- **Well-tested**: Comprehensive test coverage ensures reliability

## Files Changed

- `internal/core/logengine/logger.go` - Core implementation with RWMutex
- `internal/core/logengine/logger_test.go` - Comprehensive test suite (165 new lines)
- `logger.go` - Updated all log functions to use configurable depth
- `logger_settings.go` - Added `WithCallerInfoDepth` function
- `README.md` - Documentation and examples

## Testing

All tests pass successfully:
- ✅ Default value validation
- ✅ Set/Get functionality
- ✅ Concurrent reads (100 readers)
- ✅ Concurrent writes (50 writers)
- ✅ Mixed concurrent operations
- ✅ All existing tests continue to pass

## Test result
```
ionlog on  hotfix/config-caller-stack-deepth [$⇕] via 🐹 v1.25.4 took 18s 
❯ make audit
go fmt ./...
go mod verify
all modules verified
go vet ./...
go run honnef.co/go/tools/cmd/staticcheck@latest -checks=all,-ST1000,-U1000 ./...
go run golang.org/x/vuln/cmd/govulncheck@latest -show verbose ./...
Fetching vulnerabilities from the database...

Checking the code against the vulnerabilities...

The package pattern matched the following 11 root packages:
  github.com/IonicHealthUsa/ionlog/internal/core/logbuilder
  github.com/IonicHealthUsa/ionlog/internal/core/runtimeinfo
  github.com/IonicHealthUsa/ionlog/internal/infrastructure/memory
  github.com/IonicHealthUsa/ionlog/internal/core/logengine
  github.com/IonicHealthUsa/ionlog/internal/infrastructure/filesystem
  github.com/IonicHealthUsa/ionlog/internal/core/rotationengine
  github.com/IonicHealthUsa/ionlog/internal/service
  github.com/IonicHealthUsa/ionlog/internal/styles
  github.com/IonicHealthUsa/ionlog/internal/usecases
  github.com/IonicHealthUsa/ionlog
  github.com/IonicHealthUsa/ionlog/benchmark
Govulncheck scanned the following 2 modules and the go1.25.4 standard library:
  github.com/IonicHealthUsa/ionlog
  github.com/cespare/xxhash@v1.1.0

No vulnerabilities found.
go test -race -vet=off ./...
?   	github.com/IonicHealthUsa/ionlog	[no test files]
ok  	github.com/IonicHealthUsa/ionlog/benchmark	(cached) [no tests to run]
ok  	github.com/IonicHealthUsa/ionlog/internal/core/logbuilder	(cached)
ok  	github.com/IonicHealthUsa/ionlog/internal/core/logengine	(cached)
ok  	github.com/IonicHealthUsa/ionlog/internal/core/rotationengine	(cached)
ok  	github.com/IonicHealthUsa/ionlog/internal/core/runtimeinfo	(cached)
ok  	github.com/IonicHealthUsa/ionlog/internal/infrastructure/filesystem	(cached)
ok  	github.com/IonicHealthUsa/ionlog/internal/infrastructure/memory	(cached)
ok  	github.com/IonicHealthUsa/ionlog/internal/service	(cached)
ok  	github.com/IonicHealthUsa/ionlog/internal/styles	(cached)
ok  	github.com/IonicHealthUsa/ionlog/internal/usecases	(cached)
 ```