### PR TITLE
fix: added a fuction to handle json escaping correctly

### DIFF
--- a/internal/core/logbuilder/logbuilder.go
+++ b/internal/core/logbuilder/logbuilder.go
@@ -46,6 +46,49 @@ func (l *logBuilder) writeString(str string) {
 	}
 }
 
+// writeJSONStringEscaped writes str into the buffer with JSON string escaping.
+// This ensures that newlines, quotes, backslashes, and other control chars
+// produce valid JSON so downstream consumers can unmarshal.
+func (l *logBuilder) writeJSONStringEscaped(str string) {
+	for _, b := range []byte(str) {
+		switch b {
+		case '"':
+			l.writeByte('\\')
+			l.writeByte('"')
+		case '\\':
+			l.writeByte('\\')
+			l.writeByte('\\')
+		case '\n':
+			l.writeByte('\\')
+			l.writeByte('n')
+		case '\r':
+			l.writeByte('\\')
+			l.writeByte('r')
+		case '\t':
+			l.writeByte('\\')
+			l.writeByte('t')
+		default:
+			if b < 0x20 {
+				l.writeByte('\\')
+				l.writeByte('u')
+				l.writeByte('0')
+				l.writeByte('0')
+				l.writeByte(hexChar(b >> 4))
+				l.writeByte(hexChar(b & 0x0f))
+			} else {
+				l.writeByte(b)
+			}
+		}
+	}
+}
+
+func hexChar(b byte) byte {
+	if b < 10 {
+		return '0' + b
+	}
+	return 'a' + (b - 10)
+}
+
 func (l *logBuilder) resetBuff() {
 	l.p = 0
 	l.writeByte('{')
@@ -61,12 +104,12 @@ func (l *logBuilder) AddFields(args ...string) {
 			l.writeByte(',')
 		}
 		l.writeByte('"')
-		l.writeString(args[i])
+		l.writeJSONStringEscaped(args[i])
 		l.writeByte('"')
 		l.writeByte(':')
 
 		l.writeByte('"')
-		l.writeString(args[i+1])
+		l.writeJSONStringEscaped(args[i+1])
 		l.writeByte('"')
 	}
 }

--- a/internal/core/logbuilder/logbuilder_test.go
+++ b/internal/core/logbuilder/logbuilder_test.go
@@ -1,6 +1,7 @@
 package logbuilder
 
 import (
+	"encoding/json"
 	"reflect"
 	"strconv"
 	"testing"
@@ -252,6 +253,24 @@ func TestSpecialCharacters(t *testing.T) {
 
 		if !reflect.DeepEqual(result, expected) {
 			t.Errorf("Special characters handling incorrect, got: %s, want: %s", result, expected)
+		}
+	})
+
+	t.Run("Escapes newlines and quotes so JSON is valid", func(t *testing.T) {
+		lb := NewLogBuilder()
+		msg := "line1\nline2\r\n\tand tab"
+		lb.AddFields("msg", msg, "quote", `say "hello"`)
+
+		result := lb.Compile()
+		var decoded map[string]string
+		if err := json.Unmarshal(result[:len(result)-1], &decoded); err != nil {
+			t.Fatalf("Compile() produced invalid JSON: %v\noutput: %s", err, result)
+		}
+		if decoded["msg"] != msg {
+			t.Errorf("msg round-trip: got %q, want %q", decoded["msg"], msg)
+		}
+		if decoded["quote"] != `say "hello"` {
+			t.Errorf("quote round-trip: got %q", decoded["quote"])
 		}
 	})
 }

--- a/internal/styles/custom_test.go
+++ b/internal/styles/custom_test.go
@@ -65,6 +65,15 @@ func TestProcessLogline(t *testing.T) {
 		}
 	})
 
+	t.Run("accepts msg with escaped newlines and quotes (valid JSON from logbuilder)", func(t *testing.T) {
+		// Logbuilder escapes \n, \r, \t, " and \ so CustomOutput can unmarshal
+		line := []byte(`{"time":"2026-01-01T12:00:00Z","level":"INFO","msg":"line1\nline2\n","file":"main.go","package":"main","function":"main","line":"42"}` + "\n")
+		_, err := processLogLine(line)
+		if err != nil {
+			t.Errorf("processLogLine with newline in msg should succeed, got: %v", err)
+		}
+	})
+
 	t.Run("should return the correct format for each level type", func(t *testing.T) {
 		testCase := [...]struct {
 			report          logengine.ReportType


### PR DESCRIPTION
- Fix JSON string escaping in logbuilder: Introduce writeJSONStringEscaped to properly escape quotes, backslashes, newlines, carriage returns, tabs, and other control characters so that log output remains valid JSON.

- Use escaping for both field names and values: Update AddFields to write keys and values via the new JSON-escaping helper instead of raw strings.

- Strengthen tests around JSON validity: Extend logbuilder tests to round-trip compiled log output through encoding/json and verify that messages and quoted strings deserialize back to their original values.

- Validate integration in styles: Add a custom_test case ensuring processLogLine correctly handles messages containing escaped newlines and quotes produced by the updated logbuilder.